### PR TITLE
GoogleログインのTripAppバックエンドとのAPI通信部分を実装

### DIFF
--- a/lib/core/extensions/google_sign_in_account.dart
+++ b/lib/core/extensions/google_sign_in_account.dart
@@ -1,0 +1,12 @@
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/google_account/google_account.dart';
+import 'google_sign_in_authentication.dart';
+
+extension GoogleSignInAccountExtensions on GoogleSignInAccount {
+  GoogleAccount toEntity(GoogleSignInAuthentication googleAuth) {
+    return GoogleAccount(
+      displayName: displayName ?? '',
+      credential: googleAuth.toEntity(),
+    );
+  }
+}

--- a/lib/core/extensions/google_sign_in_authentication.dart
+++ b/lib/core/extensions/google_sign_in_authentication.dart
@@ -1,0 +1,16 @@
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/third_party_credential/third_party_credential.dart';
+
+extension GoogleSignInAuthenticationExtension on GoogleSignInAuthentication {
+  /// トークンの情報が抜け落ちている場合有効ではない扱いとする
+  bool get isValid => idToken != null && accessToken != null;
+
+  /// 独自エンティティへ変換する。
+  /// 事前にisValidでトークンの情報があることを仮定して非null演算を行ってます。
+  ThirdPartyCredential toEntity() {
+    return ThirdPartyCredential(
+      idToken: idToken!,
+      accessToken: accessToken!,
+    );
+  }
+}

--- a/lib/features/auth/data/repositories/google_login_repository.dart
+++ b/lib/features/auth/data/repositories/google_login_repository.dart
@@ -2,7 +2,9 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../core/exception/app_exception.dart';
-import '../../domain/entity/third_party_credential/third_party_credential.dart';
+import '../../../../core/extensions/google_sign_in_account.dart';
+import '../../../../core/extensions/google_sign_in_authentication.dart';
+import '../../domain/entity/google_account/google_account.dart';
 import '../../domain/repositories/google_login_interface.dart';
 
 final googleLoginRepositoryProvider =
@@ -10,21 +12,18 @@ final googleLoginRepositoryProvider =
 
 class GoogleLoginRepository implements GoogleLoginInterface {
   @override
-  Future<ThirdPartyCredential> login() async {
+  Future<GoogleAccount> login() async {
     final googleUser = await GoogleSignIn().signIn();
-    final googleAuth = await googleUser?.authentication;
+    if (googleUser == null) {
+      throw const AppException(message: 'Googleアカウントの取得に失敗しました。');
+    }
+    final googleAuth = await googleUser.authentication;
 
-    final idToken = googleAuth?.idToken;
-    final accsesToken = googleAuth?.accessToken;
 
-    if (idToken == null || accsesToken == null) {
+    if (!googleAuth.isValid) {
       throw const AppException(message: 'idToken または accessToken が取得できませんでした');
     }
 
-    // TODO(seigi0714): ユーザー登録も行うのでGoogleユーザー情報も持ったエンティティを返すようにする
-    return ThirdPartyCredential(
-      idToken: idToken,
-      accessToken: accsesToken,
-    );
+    return googleUser.toEntity(googleAuth);
   }
 }

--- a/lib/features/auth/domain/entity/google_account/google_account.dart
+++ b/lib/features/auth/domain/entity/google_account/google_account.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/third_party_credential/third_party_credential.dart';
+
+part 'google_account.freezed.dart';
+
+@freezed
+class GoogleAccount with _$GoogleAccount {
+  const factory GoogleAccount({
+    required String displayName,
+    required ThirdPartyCredential credential,
+  }) = _GoogleAccount;
+}

--- a/lib/features/auth/domain/entity/google_account/google_account.freezed.dart
+++ b/lib/features/auth/domain/entity/google_account/google_account.freezed.dart
@@ -1,0 +1,164 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'google_account.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$GoogleAccount {
+  String get displayName => throw _privateConstructorUsedError;
+  ThirdPartyCredential get credential => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $GoogleAccountCopyWith<GoogleAccount> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GoogleAccountCopyWith<$Res> {
+  factory $GoogleAccountCopyWith(
+          GoogleAccount value, $Res Function(GoogleAccount) then) =
+      _$GoogleAccountCopyWithImpl<$Res>;
+  $Res call({String displayName, ThirdPartyCredential credential});
+
+  $ThirdPartyCredentialCopyWith<$Res> get credential;
+}
+
+/// @nodoc
+class _$GoogleAccountCopyWithImpl<$Res>
+    implements $GoogleAccountCopyWith<$Res> {
+  _$GoogleAccountCopyWithImpl(this._value, this._then);
+
+  final GoogleAccount _value;
+  // ignore: unused_field
+  final $Res Function(GoogleAccount) _then;
+
+  @override
+  $Res call({
+    Object? displayName = freezed,
+    Object? credential = freezed,
+  }) {
+    return _then(_value.copyWith(
+      displayName: displayName == freezed
+          ? _value.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String,
+      credential: credential == freezed
+          ? _value.credential
+          : credential // ignore: cast_nullable_to_non_nullable
+              as ThirdPartyCredential,
+    ));
+  }
+
+  @override
+  $ThirdPartyCredentialCopyWith<$Res> get credential {
+    return $ThirdPartyCredentialCopyWith<$Res>(_value.credential, (value) {
+      return _then(_value.copyWith(credential: value));
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$_GoogleAccountCopyWith<$Res>
+    implements $GoogleAccountCopyWith<$Res> {
+  factory _$$_GoogleAccountCopyWith(
+          _$_GoogleAccount value, $Res Function(_$_GoogleAccount) then) =
+      __$$_GoogleAccountCopyWithImpl<$Res>;
+  @override
+  $Res call({String displayName, ThirdPartyCredential credential});
+
+  @override
+  $ThirdPartyCredentialCopyWith<$Res> get credential;
+}
+
+/// @nodoc
+class __$$_GoogleAccountCopyWithImpl<$Res>
+    extends _$GoogleAccountCopyWithImpl<$Res>
+    implements _$$_GoogleAccountCopyWith<$Res> {
+  __$$_GoogleAccountCopyWithImpl(
+      _$_GoogleAccount _value, $Res Function(_$_GoogleAccount) _then)
+      : super(_value, (v) => _then(v as _$_GoogleAccount));
+
+  @override
+  _$_GoogleAccount get _value => super._value as _$_GoogleAccount;
+
+  @override
+  $Res call({
+    Object? displayName = freezed,
+    Object? credential = freezed,
+  }) {
+    return _then(_$_GoogleAccount(
+      displayName: displayName == freezed
+          ? _value.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String,
+      credential: credential == freezed
+          ? _value.credential
+          : credential // ignore: cast_nullable_to_non_nullable
+              as ThirdPartyCredential,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_GoogleAccount implements _GoogleAccount {
+  const _$_GoogleAccount({required this.displayName, required this.credential});
+
+  @override
+  final String displayName;
+  @override
+  final ThirdPartyCredential credential;
+
+  @override
+  String toString() {
+    return 'GoogleAccount(displayName: $displayName, credential: $credential)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_GoogleAccount &&
+            const DeepCollectionEquality()
+                .equals(other.displayName, displayName) &&
+            const DeepCollectionEquality()
+                .equals(other.credential, credential));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(displayName),
+      const DeepCollectionEquality().hash(credential));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_GoogleAccountCopyWith<_$_GoogleAccount> get copyWith =>
+      __$$_GoogleAccountCopyWithImpl<_$_GoogleAccount>(this, _$identity);
+}
+
+abstract class _GoogleAccount implements GoogleAccount {
+  const factory _GoogleAccount(
+      {required final String displayName,
+      required final ThirdPartyCredential credential}) = _$_GoogleAccount;
+
+  @override
+  String get displayName;
+  @override
+  ThirdPartyCredential get credential;
+  @override
+  @JsonKey(ignore: true)
+  _$$_GoogleAccountCopyWith<_$_GoogleAccount> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/auth/domain/interactor/auth_interactor.dart
+++ b/lib/features/auth/domain/interactor/auth_interactor.dart
@@ -43,9 +43,16 @@ class AuthInteractor {
   }
 
   Future<void> loginWithGoogle() async {
-    final credential = await googleLoginInterface.login();
-    await firebaseAuthInterface.signInWithGoogle(credential);
-
-    // TODO(seigi0714): ユーザー登録APIをコール
+    final googleAccount = await googleLoginInterface.login();
+    await firebaseAuthInterface.signInWithGoogle(googleAccount.credential);
+    try {
+      await tripAppAuthInterface.createUserWithFirebaseIdToken(
+        name: googleAccount.displayName,
+      );
+    } on Exception catch (_) {
+      //　ユーザー登録に失敗した場合いかなる失敗でもFirebaseサインアウト
+      await firebaseAuthInterface.signOut();
+      rethrow;
+    }
   }
 }

--- a/lib/features/auth/domain/repositories/firebase_auth_interface.dart
+++ b/lib/features/auth/domain/repositories/firebase_auth_interface.dart
@@ -1,7 +1,7 @@
 import '../entity/third_party_credential/third_party_credential.dart';
 
 abstract class FirebaseAuthInterface {
-  /// Firebase customtokenを用いたログイン
+  /// Firebaseカスタムトークンを用いたログイン
   Future<void> signInWithCustomToken({
     required String customToken,
   });

--- a/lib/features/auth/domain/repositories/google_login_interface.dart
+++ b/lib/features/auth/domain/repositories/google_login_interface.dart
@@ -1,6 +1,6 @@
 
-import '../entity/third_party_credential/third_party_credential.dart';
+import '../entity/google_account/google_account.dart';
 
 abstract class GoogleLoginInterface {
-  Future<ThirdPartyCredential> login();
+  Future<GoogleAccount> login();
 }

--- a/test/feature/auth/interactor/auth_interactor_test.dart
+++ b/test/feature/auth/interactor/auth_interactor_test.dart
@@ -8,6 +8,7 @@ import 'package:trip_app_nativeapp/features/auth/data/repositories/firebase_auth
 import 'package:trip_app_nativeapp/features/auth/data/repositories/google_login_repository.dart';
 import 'package:trip_app_nativeapp/features/auth/data/repositories/line_login_repository.dart';
 import 'package:trip_app_nativeapp/features/auth/data/repositories/trip_app_auth_repository.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/google_account/google_account.dart';
 import 'package:trip_app_nativeapp/features/auth/domain/entity/oidc/oidc_info.dart';
 import 'package:trip_app_nativeapp/features/auth/domain/entity/third_party_credential/third_party_credential.dart';
 import 'package:trip_app_nativeapp/features/auth/domain/interactor/auth_interactor.dart';
@@ -39,6 +40,11 @@ Future<void> main() async {
   const testThirdPartyCredential = ThirdPartyCredential(
     idToken: 'idToken',
     accessToken: 'accessToken',
+  );
+
+  const testGoogleAccount = GoogleAccount(
+    displayName: 'google_name',
+    credential: testThirdPartyCredential,
   );
 
   /*
@@ -277,7 +283,7 @@ Future<void> main() async {
       '正常系',
       () async {
         when(mockGoogleLoginRepository.login())
-            .thenAnswer((_) async => testThirdPartyCredential);
+            .thenAnswer((_) async => testGoogleAccount);
 
         when(
           mockFirebaseAuthRepository.signInWithGoogle(testThirdPartyCredential),
@@ -328,7 +334,7 @@ Future<void> main() async {
       when(
         mockGoogleLoginRepository.login(),
       ).thenAnswer(
-        (_) async => testThirdPartyCredential,
+        (_) async => testGoogleAccount,
       );
 
       when(

--- a/test/feature/auth/interactor/auth_interactor_test.mocks.dart
+++ b/test/feature/auth/interactor/auth_interactor_test.mocks.dart
@@ -6,18 +6,20 @@
 import 'dart:async' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:trip_app_nativeapp/features/auth/domain/entity/google_account/google_account.dart'
+    as _i3;
 import 'package:trip_app_nativeapp/features/auth/domain/entity/oidc/oidc_info.dart'
     as _i2;
 import 'package:trip_app_nativeapp/features/auth/domain/entity/third_party_credential/third_party_credential.dart'
-    as _i3;
+    as _i6;
 import 'package:trip_app_nativeapp/features/auth/domain/repositories/firebase_auth_interface.dart'
     as _i4;
 import 'package:trip_app_nativeapp/features/auth/domain/repositories/google_login_interface.dart'
-    as _i7;
-import 'package:trip_app_nativeapp/features/auth/domain/repositories/line_login_interface.dart'
-    as _i6;
-import 'package:trip_app_nativeapp/features/auth/domain/repositories/trip_app_auth_interface.dart'
     as _i8;
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/line_login_interface.dart'
+    as _i7;
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/trip_app_auth_interface.dart'
+    as _i9;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -40,9 +42,8 @@ class _FakeOidcInfo_0 extends _i1.SmartFake implements _i2.OidcInfo {
         );
 }
 
-class _FakeThirdPartyCredential_1 extends _i1.SmartFake
-    implements _i3.ThirdPartyCredential {
-  _FakeThirdPartyCredential_1(
+class _FakeGoogleAccount_1 extends _i1.SmartFake implements _i3.GoogleAccount {
+  _FakeGoogleAccount_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -72,7 +73,7 @@ class MockFirebaseAuthInterface extends _i1.Mock
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
-  _i5.Future<void> signInWithGoogle(_i3.ThirdPartyCredential? credential) =>
+  _i5.Future<void> signInWithGoogle(_i6.ThirdPartyCredential? credential) =>
       (super.noSuchMethod(
         Invocation.method(
           #signInWithGoogle,
@@ -96,7 +97,7 @@ class MockFirebaseAuthInterface extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockLineLoginInterface extends _i1.Mock
-    implements _i6.LineLoginInterface {
+    implements _i7.LineLoginInterface {
   MockLineLoginInterface() {
     _i1.throwOnMissingStub(this);
   }
@@ -121,33 +122,32 @@ class MockLineLoginInterface extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGoogleLoginInterface extends _i1.Mock
-    implements _i7.GoogleLoginInterface {
+    implements _i8.GoogleLoginInterface {
   MockGoogleLoginInterface() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.Future<_i3.ThirdPartyCredential> login() => (super.noSuchMethod(
+  _i5.Future<_i3.GoogleAccount> login() => (super.noSuchMethod(
         Invocation.method(
           #login,
           [],
         ),
-        returnValue: _i5.Future<_i3.ThirdPartyCredential>.value(
-            _FakeThirdPartyCredential_1(
+        returnValue: _i5.Future<_i3.GoogleAccount>.value(_FakeGoogleAccount_1(
           this,
           Invocation.method(
             #login,
             [],
           ),
         )),
-      ) as _i5.Future<_i3.ThirdPartyCredential>);
+      ) as _i5.Future<_i3.GoogleAccount>);
 }
 
 /// A class which mocks [TripAppAuthInterface].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockTripAppAuthInterface extends _i1.Mock
-    implements _i8.TripAppAuthInterface {
+    implements _i9.TripAppAuthInterface {
   MockTripAppAuthInterface() {
     _i1.throwOnMissingStub(this);
   }
@@ -168,4 +168,15 @@ class MockTripAppAuthInterface extends _i1.Mock
         ),
         returnValue: _i5.Future<String>.value(''),
       ) as _i5.Future<String>);
+  @override
+  _i5.Future<void> createUserWithFirebaseIdToken({required String? name}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #createUserWithFirebaseIdToken,
+          [],
+          {#name: name},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }


### PR DESCRIPTION
# 概要
- Firebaseログインが済んだあとにユーザー登録APIをコールする処理を実装

# 改修内容
- Googleアカウントエンティティを作成
- interactorの修正
  - Firebaseログインに成功した場合ユーザー登録APIをコールする
  - ユーザー登録に失敗するとFirebaseログアウトを行う
