### PR TITLE
lint ルールに使用するパッケージを very_good_analysis に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # trip_app_nativeapp
 
-[![style: very good analysis](https://img.shields.io/badge/style-very_good_analysis-B22C89.svg)](https://pub.dev/packages/very_good_analysis)
+シンプルで使いやすい 旅のしおりアプリ
+
+<p align="left">
+<a href="https://github.com/shimizu-saffle/flutter-amazon-clone/actions/workflows/flutter_ci.yaml"><img src="https://github.com/shimizu-saffle/flutter-amazon-clone/actions/workflows/flutter_ci.yaml/badge.svg" alt="Flutter CI"></a>
+<a href="https://pub.dev/packages/very_good_analysis"><img src="https://img.shields.io/badge/style-very_good_analysis-B22C89.svg"></a>
+</p>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 シンプルで使いやすい 旅のしおりアプリ
 
 <p align="left">
-<a href="https://github.com/shimizu-saffle/flutter-amazon-clone/actions/workflows/flutter_ci.yaml"><img src="https://github.com/shimizu-saffle/flutter-amazon-clone/actions/workflows/flutter_ci.yaml/badge.svg" alt="Flutter CI"></a>
+<a href="https://github.com/seigi0714/trip-app-nativeapp/actions/workflows/flutter_ci.yaml"><img src="https://github.com/shimizu-saffle/flutter-amazon-clone/actions/workflows/flutter_ci.yaml/badge.svg" alt="Flutter CI"></a>
 <a href="https://pub.dev/packages/very_good_analysis"><img src="https://img.shields.io/badge/style-very_good_analysis-B22C89.svg"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
 # trip_app_nativeapp
 
-A new Flutter project.
-
-## Getting Started
-
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+[![style: very good analysis](https://img.shields.io/badge/style-very_good_analysis-B22C89.svg)](https://pub.dev/packages/very_good_analysis)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,20 +1,11 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
-include: package:pedantic_mono/analysis_options.yaml
+include: package:very_good_analysis/analysis_options.yaml
 
 analyzer:
   exclude:
     - 'lib/env/env.dart'
     - 'lib/firebase_options.dart'
   errors:
-    avoid_classes_with_only_static_members: ignore
+    public_member_api_docs: ignore
     one_member_abstracts: ignore
 
 linter:

--- a/lib/core/exception/exception_handler.dart
+++ b/lib/core/exception/exception_handler.dart
@@ -3,11 +3,10 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:trip_app_nativeapp/core/constants/string.dart';
 import 'package:trip_app_nativeapp/core/exception/api_exception.dart';
 import 'package:trip_app_nativeapp/features/auth/data/repositories/firebase_auth_repository.dart';
-
-import '../../view/widgets/helpers/scaffold_messenger.dart';
-import '../constants/string.dart';
+import 'package:trip_app_nativeapp/view/widgets/helpers/scaffold_messenger.dart';
 
 part 'exception_handler.g.dart';
 

--- a/lib/core/extensions/google_sign_in_account.dart
+++ b/lib/core/extensions/google_sign_in_account.dart
@@ -1,6 +1,6 @@
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:trip_app_nativeapp/core/extensions/google_sign_in_authentication.dart';
 import 'package:trip_app_nativeapp/features/auth/domain/entity/google_account/google_account.dart';
-import 'google_sign_in_authentication.dart';
 
 extension GoogleSignInAccountExtensions on GoogleSignInAccount {
   GoogleAccount toEntity(GoogleSignInAuthentication googleAuth) {

--- a/lib/core/http/api_client/abstract_api_client.dart
+++ b/lib/core/http/api_client/abstract_api_client.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
-
-import '../response/api_response/api_response.dart';
+import 'package:trip_app_nativeapp/core/http/response/api_response/api_response.dart';
 
 /// dio.dart の abstract class Dio の形式に沿った
 /// API クライアントの抽象クラス

--- a/lib/core/http/api_client/api_client.dart
+++ b/lib/core/http/api_client/api_client.dart
@@ -1,13 +1,12 @@
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:trip_app_nativeapp/core/constants/json.dart';
+import 'package:trip_app_nativeapp/core/exception/api_exception.dart';
+import 'package:trip_app_nativeapp/core/http/api_client/abstract_api_client.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/api_destination.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/dio/dio.dart';
-
-import '../../constants/json.dart';
-import '../../exception/api_exception.dart';
-import '../response/api_response/api_response.dart';
-import '../response/error_response/error_response.dart';
-import 'abstract_api_client.dart';
+import 'package:trip_app_nativeapp/core/http/response/api_response/api_response.dart';
+import 'package:trip_app_nativeapp/core/http/response/error_response/error_response.dart';
 
 part 'api_client.g.dart';
 

--- a/lib/core/http/api_client/dio/baseurl.dart
+++ b/lib/core/http/api_client/dio/baseurl.dart
@@ -1,7 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:trip_app_nativeapp/core/env.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/api_destination.dart';
-
-import '../../../env.dart';
 
 part 'baseurl.g.dart';
 

--- a/lib/core/http/api_client/dio/dio.dart
+++ b/lib/core/http/api_client/dio/dio.dart
@@ -2,13 +2,12 @@ import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:trip_app_nativeapp/core/constants/number.dart';
+import 'package:trip_app_nativeapp/core/http/api_client/api_destination.dart';
+import 'package:trip_app_nativeapp/core/http/api_client/dio/baseurl.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/dio/header_interceptor.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/dio/request_interceptor.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/dio/response_interceptor.dart';
-
-import '../../../constants/number.dart';
-import '../api_destination.dart';
-import 'baseurl.dart';
 
 part 'dio.g.dart';
 

--- a/lib/core/http/api_client/dio/header_interceptor.dart
+++ b/lib/core/http/api_client/dio/header_interceptor.dart
@@ -1,8 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:trip_app_nativeapp/core/cache/login_token.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/api_destination.dart';
-
-import '../../../cache/login_token.dart';
 
 part 'header_interceptor.g.dart';
 

--- a/lib/core/http/api_client/dio/request_interceptor.dart
+++ b/lib/core/http/api_client/dio/request_interceptor.dart
@@ -2,8 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import '../../../debug/logger.dart';
+import 'package:trip_app_nativeapp/core/debug/logger.dart';
 
 part 'request_interceptor.g.dart';
 

--- a/lib/core/http/api_client/dio/response_interceptor.dart
+++ b/lib/core/http/api_client/dio/response_interceptor.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import '../../../debug/logger.dart';
+import 'package:trip_app_nativeapp/core/debug/logger.dart';
 
 part 'response_interceptor.g.dart';
 

--- a/lib/core/trip_app.dart
+++ b/lib/core/trip_app.dart
@@ -3,10 +3,9 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nil/nil.dart';
 import 'package:trip_app_nativeapp/core/constants/color.dart';
-
-import '../router.dart';
-import '../view/pages/constant_page.dart';
-import '../view/widgets/helpers/scaffold_messenger.dart';
+import 'package:trip_app_nativeapp/router.dart';
+import 'package:trip_app_nativeapp/view/pages/constant_page.dart';
+import 'package:trip_app_nativeapp/view/widgets/helpers/scaffold_messenger.dart';
 
 class TripApp extends StatelessWidget {
   const TripApp({

--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -1,12 +1,11 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import '../../../core/enum/login_type.dart';
-import '../../../core/exception/exception_handler.dart';
-import '../../../view/widgets/helpers/scaffold_messenger.dart';
-import '../data/repositories/firebase_auth_repository.dart';
-import '../domain/interactor/auth_interactor.dart';
+import 'package:trip_app_nativeapp/core/enum/login_type.dart';
+import 'package:trip_app_nativeapp/core/exception/exception_handler.dart';
+import 'package:trip_app_nativeapp/features/auth/data/repositories/firebase_auth_repository.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/interactor/auth_interactor.dart';
+import 'package:trip_app_nativeapp/view/widgets/helpers/scaffold_messenger.dart';
 
 part 'auth_controller.g.dart';
 

--- a/lib/features/auth/data/models/post_login_response/post_login_response.dart
+++ b/lib/features/auth/data/models/post_login_response/post_login_response.dart
@@ -1,6 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-
-import '../../../domain/entity/custom_token.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/custom_token.dart';
 
 part 'post_login_response.freezed.dart';
 part 'post_login_response.g.dart';

--- a/lib/features/auth/data/repositories/firebase_auth_repository.dart
+++ b/lib/features/auth/data/repositories/firebase_auth_repository.dart
@@ -1,8 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:trip_app_nativeapp/features/auth/domain/entity/third_party_credential/third_party_credential.dart';
-
-import '../../domain/repositories/firebase_auth_interface.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/firebase_auth_interface.dart';
 
 part 'firebase_auth_repository.g.dart';
 

--- a/lib/features/auth/data/repositories/google_login_repository.dart
+++ b/lib/features/auth/data/repositories/google_login_repository.dart
@@ -1,11 +1,10 @@
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import '../../../../core/exception/app_exception.dart';
-import '../../../../core/extensions/google_sign_in_account.dart';
-import '../../../../core/extensions/google_sign_in_authentication.dart';
-import '../../domain/entity/google_account/google_account.dart';
-import '../../domain/repositories/google_login_interface.dart';
+import 'package:trip_app_nativeapp/core/exception/app_exception.dart';
+import 'package:trip_app_nativeapp/core/extensions/google_sign_in_account.dart';
+import 'package:trip_app_nativeapp/core/extensions/google_sign_in_authentication.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/google_account/google_account.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/google_login_interface.dart';
 
 part 'google_login_repository.g.dart';
 

--- a/lib/features/auth/data/repositories/line_login_repository.dart
+++ b/lib/features/auth/data/repositories/line_login_repository.dart
@@ -1,9 +1,8 @@
 import 'package:flutter_line_sdk/flutter_line_sdk.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import '../../../../core/exception/app_exception.dart';
-import '../../domain/entity/oidc/oidc_info.dart';
-import '../../domain/repositories/line_login_interface.dart';
+import 'package:trip_app_nativeapp/core/exception/app_exception.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/oidc/oidc_info.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/line_login_interface.dart';
 
 part 'line_login_repository.g.dart';
 

--- a/lib/features/auth/data/repositories/trip_app_auth_repository.dart
+++ b/lib/features/auth/data/repositories/trip_app_auth_repository.dart
@@ -1,9 +1,8 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import '../../../../core/http/api_client/api_client.dart';
-import '../../domain/entity/custom_token.dart';
-import '../../domain/repositories/trip_app_auth_interface.dart';
-import '../models/post_login_response/post_login_response.dart';
+import 'package:trip_app_nativeapp/core/http/api_client/api_client.dart';
+import 'package:trip_app_nativeapp/features/auth/data/models/post_login_response/post_login_response.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/custom_token.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/trip_app_auth_interface.dart';
 
 part 'trip_app_auth_repository.g.dart';
 

--- a/lib/features/auth/domain/interactor/auth_interactor.dart
+++ b/lib/features/auth/domain/interactor/auth_interactor.dart
@@ -2,12 +2,11 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:trip_app_nativeapp/features/auth/data/repositories/firebase_auth_repository.dart';
 import 'package:trip_app_nativeapp/features/auth/data/repositories/google_login_repository.dart';
 import 'package:trip_app_nativeapp/features/auth/data/repositories/line_login_repository.dart';
-
-import '../../data/repositories/trip_app_auth_repository.dart';
-import '../repositories/firebase_auth_interface.dart';
-import '../repositories/google_login_interface.dart';
-import '../repositories/line_login_interface.dart';
-import '../repositories/trip_app_auth_interface.dart';
+import 'package:trip_app_nativeapp/features/auth/data/repositories/trip_app_auth_repository.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/firebase_auth_interface.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/google_login_interface.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/line_login_interface.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/repositories/trip_app_auth_interface.dart';
 
 part 'auth_interactor.g.dart';
 

--- a/lib/features/auth/domain/repositories/firebase_auth_interface.dart
+++ b/lib/features/auth/domain/repositories/firebase_auth_interface.dart
@@ -1,12 +1,14 @@
-import '../entity/third_party_credential/third_party_credential.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/third_party_credential/third_party_credential.dart';
 
 abstract class FirebaseAuthInterface {
   /// Firebaseカスタムトークンを用いたログイン
   Future<void> signInWithCustomToken({
     required String customToken,
   });
+
   ///　Oauthログインで生成されたCredentialを用いたログイン
   Future<void> signInWithGoogle(ThirdPartyCredential credential);
+
   /// ログアウト
   Future<void> signOut();
 }

--- a/lib/features/auth/domain/repositories/google_login_interface.dart
+++ b/lib/features/auth/domain/repositories/google_login_interface.dart
@@ -1,5 +1,4 @@
-
-import '../entity/google_account/google_account.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/google_account/google_account.dart';
 
 abstract class GoogleLoginInterface {
   Future<GoogleAccount> login();

--- a/lib/features/auth/domain/repositories/line_login_interface.dart
+++ b/lib/features/auth/domain/repositories/line_login_interface.dart
@@ -1,4 +1,4 @@
-import '../entity/oidc/oidc_info.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/oidc/oidc_info.dart';
 
 abstract class LineLoginInterface {
   Future<OidcInfo> login();

--- a/lib/features/auth/domain/repositories/trip_app_auth_interface.dart
+++ b/lib/features/auth/domain/repositories/trip_app_auth_interface.dart
@@ -1,4 +1,4 @@
-import '../entity/custom_token.dart';
+import 'package:trip_app_nativeapp/features/auth/domain/entity/custom_token.dart';
 
 abstract class TripAppAuthInterface {
   /// LINE IdTokenを用いたユーザー登録

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,9 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_line_sdk/flutter_line_sdk.dart';
 import 'package:trip_app_nativeapp/core/env.dart';
-
-import 'core/firebase_options.dart';
-import 'core/trip_app.dart';
+import 'package:trip_app_nativeapp/core/firebase_options.dart';
+import 'package:trip_app_nativeapp/core/trip_app.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:trip_app_nativeapp/features/auth/controller/auth_controller.dart';
+import 'package:trip_app_nativeapp/view/pages/error_page.dart';
+import 'package:trip_app_nativeapp/view/pages/home_page.dart';
 import 'package:trip_app_nativeapp/view/pages/loading_page.dart';
 import 'package:trip_app_nativeapp/view/pages/login_page.dart';
-
-import 'features/auth/controller/auth_controller.dart';
-import 'view/pages/error_page.dart';
-import 'view/pages/home_page.dart';
 
 part 'router.g.dart';
 

--- a/lib/view/pages/constant_page.dart
+++ b/lib/view/pages/constant_page.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-
-import '../../core/debug/logger.dart';
-import '../widgets/loading.dart';
+import 'package:trip_app_nativeapp/core/debug/logger.dart';
+import 'package:trip_app_nativeapp/view/widgets/loading.dart';
 
 /// MaterialApp.router の builder で返すことによって
 /// すべてのページ上に ConstantPage を 挿入することができるので

--- a/lib/view/pages/home_page.dart
+++ b/lib/view/pages/home_page.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
-
-import '../../features/auth/controller/auth_controller.dart';
+import 'package:trip_app_nativeapp/features/auth/controller/auth_controller.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});

--- a/lib/view/pages/loading_page.dart
+++ b/lib/view/pages/loading_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import '../widgets/loading.dart';
+import 'package:trip_app_nativeapp/view/widgets/loading.dart';
 
 class LoadingPage extends StatelessWidget {
   const LoadingPage({super.key});

--- a/lib/view/pages/login_page.dart
+++ b/lib/view/pages/login_page.dart
@@ -2,14 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lottie/lottie.dart';
+import 'package:trip_app_nativeapp/core/constants/color.dart';
 import 'package:trip_app_nativeapp/core/enum/login_type.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
-
-import '../../core/constants/color.dart';
-import '../../core/gen/assets.gen.dart';
-import '../../features/auth/controller/auth_controller.dart';
-import '../widgets/brand_button.dart';
-import '../widgets/loading.dart';
+import 'package:trip_app_nativeapp/core/gen/assets.gen.dart';
+import 'package:trip_app_nativeapp/features/auth/controller/auth_controller.dart';
+import 'package:trip_app_nativeapp/view/widgets/brand_button.dart';
+import 'package:trip_app_nativeapp/view/widgets/loading.dart';
 
 class LoginPage extends HookConsumerWidget {
   const LoginPage({super.key});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -688,13 +688,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
-  pedantic_mono:
-    dependency: "direct dev"
-    description:
-      name: pedantic_mono
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.20.0"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -966,6 +966,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  very_good_analysis:
+    dependency: "direct main"
+    description:
+      name: very_good_analysis
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,6 @@ dev_dependencies:
   freezed: ^2.1.0+1
   http_mock_adapter: ^0.3.3
   json_serializable: ^6.3.1
-  pedantic_mono: ^1.20.0
   riverpod_generator: ^1.0.6
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   riverpod_annotation: ^1.0.6
   roggle: ^0.2.1+1
   shared_preferences: ^2.0.15
+  very_good_analysis: ^3.1.0
 
 dev_dependencies:
   build_runner: ^2.2.0


### PR DESCRIPTION
## やったこと
- lint ルールに使用するパッケージを [Very Good Ventures](https://github.com/VGVentures) 製の [very_good_analysis](https://pub.dev/packages/very_good_analysis) に変更
-  README を更新
- very_good_analysis で採用されている、always_use_package_imports ルールに従って、すべての import文を絶対パスに変更

## やった理由
コード品質を保つために、デフォルトの lint ルールよりも厳しくしたいけれど、自分たちで考えて一つずつ追加していくよりも、信頼できる誰かが作ったルールを使うのがお手軽で良い。

これまで使っていた pedantic_mono は個人開発パッケージで、very_good_analysis は Google 等のクライアントを相手にする、Flutter開発コンサルタントの Very Good Ventures が開発したパッケージなので、より信頼性が高く、アップデートなども早そうなので変えてみました！（個人的に Very Good Ventures が好きというのもある 😆）