### PR TITLE
Dependabot の PR でも Report Test が実行できるようにする

### DIFF
--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -15,6 +15,7 @@ jobs:
     name: Flutter Test (ubuntu-latest)
     permissions:
       actions: write
+      checks: write
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -15,6 +15,7 @@ jobs:
     name: Flutter Test (ubuntu-latest)
     permissions:
       actions: write
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -14,7 +14,6 @@ jobs:
   flutter_test:
     name: Flutter Test (ubuntu-latest)
     permissions:
-      actions: write
       checks: write
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   flutter_test:
     name: Flutter Test (ubuntu-latest)
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## 概要
Dependabot の PR でも、GitHub Workflow の Report Test ジョブが実行できるようにするため、ジョブの permissions セクションに `checks: write` と `contents: read` を追加。

Dependabot による、push および pull_request イベントのワークフロー実行は、ジョブの permissions セクションで指定された権限が尊重されるようになっていて、permissions セクションで権限指定をしていないと、Dependabot に付与される `GITHUB_TOKEN` の権限は、デフォルトの設定で読み取り専用になっている。

そのため、Settings > Actions > General > Workflow permissions を Read and write permissions にしていても、test-report.log ファイルを生成できずに、Report Test ジョブに失敗していたのではないかと考えています。

`checks: write` で、Check Runs API のアクセス権限が付与されるようにして、ワークフローの実行結果を GitHub 上に表示できるようにしています。

### References
- [Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
- [GitHub Actions: Workflows triggered by Dependabot PRs will respect permissions key in workflows](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/)
- [GitHub Actions: Workflows triggered by Dependabot PRs will run with read-only permissions](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)
