### PR TITLE
Auth 関連の改修

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,7 @@ android {
         applicationId "com.seigiruka.trip_app_nativeapp"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -14,6 +14,14 @@
       },
       "oauth_client": [
         {
+          "client_id": "274154645467-bnptd82lpmtmb1nfduob071qfi81ec9p.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.seigiruka.trip_app_nativeapp",
+            "certificate_hash": "470e0cebba0184202205ef181338c1c1f80b4dbf"
+          }
+        },
+        {
           "client_id": "274154645467-duif0it6o5oqmg6o77lup3mupf0emnh9.apps.googleusercontent.com",
           "client_type": 3
         }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -49,25 +49,25 @@ PODS:
     - AppAuth (~> 1.5)
     - GTMAppAuth (~> 1.3)
     - GTMSessionFetcher/Core (< 3.0, >= 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.8.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.10.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.8.0):
+  - GoogleUtilities/Environment (7.10.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.8.0):
+  - GoogleUtilities/Logger (7.10.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.8.0):
+  - GoogleUtilities/Network (7.10.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.8.0)"
-  - GoogleUtilities/Reachability (7.8.0):
+  - "GoogleUtilities/NSData+zlib (7.10.0)"
+  - GoogleUtilities/Reachability (7.10.0):
     - GoogleUtilities/Logger
   - GTMAppAuth (1.3.1):
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
-  - GTMSessionFetcher/Core (2.1.0)
+  - GTMSessionFetcher/Core (2.3.0)
   - LineSDKSwift (5.9.0):
     - LineSDKSwift/Core (= 5.9.0)
   - LineSDKSwift/Core (5.9.0)
@@ -138,9 +138,9 @@ SPEC CHECKSUMS:
   google_sign_in_ios: 4f85eb9f937450765c8573bb85fd8cd6a5af675c
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
-  GoogleUtilities: 1d20a6ad97ef46f67bbdec158ce00563a671ebb7
+  GoogleUtilities: bad72cb363809015b1f7f19beb1f1cd23c589f95
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
-  GTMSessionFetcher: ffbb25ec00ebcb5201adab0a56d808f6f1902d9f
+  GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
   LineSDKSwift: 97d6306ca17ae41520f29eb5dff4077dd81f08b2
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02

--- a/lib/core/http/api_client/dio/header_interceptor.dart
+++ b/lib/core/http/api_client/dio/header_interceptor.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:trip_app_nativeapp/core/cache/login_token.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/api_destination.dart';
@@ -12,7 +13,7 @@ HeaderInterceptor headerInterceptor(
 ) {
   return HeaderInterceptor(
     apiDestination,
-    ref.watch(loginTokenProvider.future),
+    ref,
   );
 }
 
@@ -20,13 +21,13 @@ HeaderInterceptor headerInterceptor(
 class HeaderInterceptor extends Interceptor {
   HeaderInterceptor(
     this._apiDestination,
-    this._loginTokenProvider, [
+    this._ref, [
     this.overwriteUrl,
   ]);
 
   String? overwriteUrl;
   final ApiDestination _apiDestination;
-  final Future<String> _loginTokenProvider;
+  final Ref _ref;
 
   @override
   Future<void> onRequest(
@@ -38,7 +39,7 @@ class HeaderInterceptor extends Interceptor {
     options.headers['Accept'] = 'application/json';
 
     if (_apiDestination.isRequiredToken) {
-      final loginToken = await _loginTokenProvider;
+      final loginToken = await _ref.read(loginTokenProvider.future);
       options.headers['Authorization'] = 'Bearer $loginToken';
     }
 

--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -6,6 +6,7 @@ import 'package:trip_app_nativeapp/core/exception/exception_handler.dart';
 import 'package:trip_app_nativeapp/features/auth/data/repositories/firebase_auth_repository.dart';
 import 'package:trip_app_nativeapp/features/auth/domain/interactor/auth_interactor.dart';
 import 'package:trip_app_nativeapp/view/widgets/helpers/scaffold_messenger.dart';
+import 'package:trip_app_nativeapp/view/widgets/loading.dart';
 
 part 'auth_controller.g.dart';
 
@@ -14,31 +15,37 @@ final firebaseAuthUserProvider = StreamProvider.autoDispose<User?>(
 );
 
 @riverpod
-Future<void> login(
-  LoginRef ref,
-  LoginType loginType,
-) async {
-  try {
-    switch (loginType) {
-      case LoginType.line:
-        await ref.read(authInteractorProvider).loginWithLINE();
-        break;
-      case LoginType.google:
-        await ref.read(authInteractorProvider).loginWithGoogle();
-        break;
-    }
-    ref.read(scaffoldMessengerHelperProvider).showSnackBar('ログインしました 🙌');
-  } on Exception catch (e) {
-    ref.read(exceptionHandlerProvider).handleException(e);
-  }
-}
+AuthController authController(AuthControllerRef ref) => AuthController(ref);
 
-@riverpod
-Future<void> logOut(LogOutRef ref) async {
-  try {
-    await ref.read(firebaseAuthRepositoryProvider).signOut();
-    ref.read(scaffoldMessengerHelperProvider).showSnackBar('ログアウトしました 😌');
-  } on Exception catch (e) {
-    ref.read(exceptionHandlerProvider).handleException(e);
+class AuthController {
+  AuthController(this._ref);
+
+  final Ref _ref;
+
+  Future<void> login(LoginType loginType) async {
+    _ref.read(overlayLoadingProvider.notifier).state = true;
+    try {
+      switch (loginType) {
+        case LoginType.line:
+          await _ref.read(authInteractorProvider).loginWithLINE();
+          break;
+        case LoginType.google:
+          await _ref.read(authInteractorProvider).loginWithGoogle();
+          break;
+      }
+    } on Exception catch (e) {
+      _ref.read(exceptionHandlerProvider).handleException(e);
+    } finally {
+      _ref.read(overlayLoadingProvider.notifier).state = false;
+    }
+  }
+
+  Future<void> logOut() async {
+    try {
+      await _ref.read(firebaseAuthRepositoryProvider).signOut();
+      _ref.read(scaffoldMessengerHelperProvider).showSnackBar('ログアウトしました 😌');
+    } on Exception catch (e) {
+      _ref.read(exceptionHandlerProvider).handleException(e);
+    }
   }
 }

--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -33,6 +33,7 @@ class AuthController {
           await _ref.read(authInteractorProvider).loginWithGoogle();
           break;
       }
+      _ref.read(scaffoldMessengerHelperProvider).showSnackBar('ログインしました 🙌');
     } on Exception catch (e) {
       _ref.read(exceptionHandlerProvider).handleException(e);
     } finally {

--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -23,7 +23,7 @@ class AuthController {
   final Ref _ref;
 
   Future<void> login(LoginType loginType) async {
-    _ref.read(overlayLoadingProvider.notifier).state = true;
+    _ref.read(overlayLoadingProvider.notifier).startLoading();
     try {
       switch (loginType) {
         case LoginType.line:
@@ -36,7 +36,7 @@ class AuthController {
     } on Exception catch (e) {
       _ref.read(exceptionHandlerProvider).handleException(e);
     } finally {
-      _ref.read(overlayLoadingProvider.notifier).state = false;
+      _ref.read(overlayLoadingProvider.notifier).endLoading();
     }
   }
 

--- a/lib/features/auth/controller/auth_controller.g.dart
+++ b/lib/features/auth/controller/auth_controller.g.dart
@@ -31,81 +31,14 @@ class _SystemHash {
   }
 }
 
-String $loginHash() => r'35fdd451a5d808a1e69af28d2da2dcc7360f1ac8';
+String $authControllerHash() => r'59574e6e1cdcabbe18cb9e242363875abd753473';
 
-/// See also [login].
-class LoginProvider extends AutoDisposeFutureProvider<void> {
-  LoginProvider(
-    this.loginType,
-  ) : super(
-          (ref) => login(
-            ref,
-            loginType,
-          ),
-          from: loginProvider,
-          name: r'loginProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product') ? null : $loginHash,
-        );
-
-  final LoginType loginType;
-
-  @override
-  bool operator ==(Object other) {
-    return other is LoginProvider && other.loginType == loginType;
-  }
-
-  @override
-  int get hashCode {
-    var hash = _SystemHash.combine(0, runtimeType.hashCode);
-    hash = _SystemHash.combine(hash, loginType.hashCode);
-
-    return _SystemHash.finish(hash);
-  }
-}
-
-typedef LoginRef = AutoDisposeFutureProviderRef<void>;
-
-/// See also [login].
-final loginProvider = LoginFamily();
-
-class LoginFamily extends Family<AsyncValue<void>> {
-  LoginFamily();
-
-  LoginProvider call(
-    LoginType loginType,
-  ) {
-    return LoginProvider(
-      loginType,
-    );
-  }
-
-  @override
-  AutoDisposeFutureProvider<void> getProviderOverride(
-    covariant LoginProvider provider,
-  ) {
-    return call(
-      provider.loginType,
-    );
-  }
-
-  @override
-  List<ProviderOrFamily>? get allTransitiveDependencies => null;
-
-  @override
-  List<ProviderOrFamily>? get dependencies => null;
-
-  @override
-  String? get name => r'loginProvider';
-}
-
-String $logOutHash() => r'81532b889defb2a5a11c08d2f7ec85f6bffa247e';
-
-/// See also [logOut].
-final logOutProvider = AutoDisposeFutureProvider<void>(
-  logOut,
-  name: r'logOutProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $logOutHash,
+/// See also [authController].
+final authControllerProvider = AutoDisposeProvider<AuthController>(
+  authController,
+  name: r'authControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : $authControllerHash,
 );
-typedef LogOutRef = AutoDisposeFutureProviderRef<void>;
+typedef AuthControllerRef = AutoDisposeProviderRef<AuthController>;

--- a/lib/features/auth/data/repositories/trip_app_auth_repository.dart
+++ b/lib/features/auth/data/repositories/trip_app_auth_repository.dart
@@ -41,7 +41,7 @@ class TripAppAuthRepository implements TripAppAuthInterface {
   @override
   Future<void> createUserWithFirebaseIdToken({required String name}) async {
     await privateV1Client.post(
-      '/auth/signup/firebase_id_token',
+      '/auth/login/firebase_id_token',
       data: <String, String>{
         'name': name,
       },

--- a/lib/features/auth/data/repositories/trip_app_auth_repository.dart
+++ b/lib/features/auth/data/repositories/trip_app_auth_repository.dart
@@ -38,6 +38,9 @@ class TripAppAuthRepository implements TripAppAuthInterface {
     return PostLoginResponse.fromJson(response.data).customToken;
   }
 
+  /// アカウントが trip-app-backend に存在しない場合は新規登録が行われる
+  ///
+  /// 存在する場合は ユーザーデータが返されるだけ
   @override
   Future<void> createUserWithFirebaseIdToken({required String name}) async {
     await privateV1Client.post(

--- a/lib/view/pages/home_page.dart
+++ b/lib/view/pages/home_page.dart
@@ -23,7 +23,7 @@ class HomePage extends ConsumerWidget {
               ),
               const SizedBox(height: 16),
               ElevatedButton(
-                onPressed: () => ref.read(logOutProvider.future),
+                onPressed: () => ref.read(authControllerProvider).logOut(),
                 child: const Text('ログアウト'),
               ),
             ],

--- a/lib/view/pages/login_page.dart
+++ b/lib/view/pages/login_page.dart
@@ -8,7 +8,6 @@ import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 import 'package:trip_app_nativeapp/core/gen/assets.gen.dart';
 import 'package:trip_app_nativeapp/features/auth/controller/auth_controller.dart';
 import 'package:trip_app_nativeapp/view/widgets/brand_button.dart';
-import 'package:trip_app_nativeapp/view/widgets/loading.dart';
 
 class LoginPage extends HookConsumerWidget {
   const LoginPage({super.key});
@@ -43,11 +42,8 @@ class LoginPage extends HookConsumerWidget {
                   size: context.displaySize.width * 0.08,
                 ),
                 backgroundColor: lineGreen,
-                onPressed: () async {
-                  ref.read(overlayLoadingProvider.notifier).state = true;
-                  await ref.read(loginProvider(LoginType.line).future);
-                  ref.read(overlayLoadingProvider.notifier).state = false;
-                },
+                onPressed: () =>
+                    ref.read(authControllerProvider).login(LoginType.line),
               ),
               const Spacer(),
               BrandButton(
@@ -57,11 +53,8 @@ class LoginPage extends HookConsumerWidget {
                   height: context.displaySize.width * 0.08,
                 ),
                 backgroundColor: Colors.white,
-                onPressed: () async {
-                  ref.read(overlayLoadingProvider.notifier).state = true;
-                  await ref.read(loginProvider(LoginType.google).future);
-                  ref.read(overlayLoadingProvider.notifier).state = false;
-                },
+                onPressed: () =>
+                    ref.read(authControllerProvider).login(LoginType.google),
               ),
               const Spacer(),
               BrandButton(

--- a/lib/view/widgets/loading.dart
+++ b/lib/view/widgets/loading.dart
@@ -11,6 +11,10 @@ class OverlayLoading extends _$OverlayLoading {
   bool build() {
     return false;
   }
+
+  void startLoading() => state = true;
+
+  void endLoading() => state = false;
 }
 
 /// プライマリカラーの SpinkitCircle を表示する

--- a/test/feature/auth/controller/auth_controller_test.dart
+++ b/test/feature/auth/controller/auth_controller_test.dart
@@ -68,7 +68,7 @@ Future<void> main() async {
     reset(mockFirebaseAuthRepository);
   });
 
-  group('loginController', () {
+  group('login', () {
     test('正常系 LINEログイン', () async {
       when(mockAuthInteractor.loginWithLINE()).thenAnswer((_) async {});
       when(
@@ -78,7 +78,7 @@ Future<void> main() async {
       ).thenReturn(null);
 
       await expectLater(
-        providerContainer.read(loginProvider(LoginType.line).future),
+        providerContainer.read(authControllerProvider).login(LoginType.line),
         completes,
       );
 
@@ -99,7 +99,7 @@ Future<void> main() async {
       ).thenReturn(null);
 
       await expectLater(
-        providerContainer.read(loginProvider(LoginType.google).future),
+        providerContainer.read(authControllerProvider).login(LoginType.google),
         completes,
       );
 
@@ -120,7 +120,7 @@ Future<void> main() async {
       ).thenReturn(null);
 
       await expectLater(
-        providerContainer.read(loginProvider(LoginType.line).future),
+        providerContainer.read(authControllerProvider).login(LoginType.line),
         completes,
       );
 
@@ -142,7 +142,7 @@ Future<void> main() async {
       ).thenReturn(null);
 
       await expectLater(
-        providerContainer.read(loginProvider(LoginType.google).future),
+        providerContainer.read(authControllerProvider).login(LoginType.google),
         completes,
       );
 
@@ -156,7 +156,7 @@ Future<void> main() async {
     });
   });
 
-  group('logOutController', () {
+  group('logOut', () {
     test('正常系', () async {
       when(mockFirebaseAuthRepository.signOut()).thenAnswer((_) async {});
       when(
@@ -164,7 +164,7 @@ Future<void> main() async {
       ).thenReturn(null);
 
       await expectLater(
-        providerContainer.read(logOutProvider.future),
+        providerContainer.read(authControllerProvider).logOut(),
         completes,
       );
 
@@ -179,7 +179,7 @@ Future<void> main() async {
       ).thenReturn(null);
 
       await expectLater(
-        providerContainer.read(logOutProvider.future),
+        providerContainer.read(authControllerProvider).logOut(),
         completes,
       );
 


### PR DESCRIPTION
## 変更点
- Android でのビルドエラーを解決するため `android/app/build.gradle` の minSdkVersion を 21 に設定
- 開発環境の Android で Google ログインできるように、Firebase にデバッグ用のフィンガープリントを追加
- `OverlayLoading` の値の操作や、エラーハンドリングを集約する目的で `AuthController` を定義
- ログイン失敗時にオーバーレイローディングが回り続けてしまう不具合を修正