### PR TITLE
旅のしおり一覧取得機能（リポジトリ層）

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -8,64 +8,54 @@ PODS:
   - connectivity_plus (0.0.1):
     - Flutter
     - ReachabilitySwift
-  - Firebase/Auth (9.6.0):
+  - Firebase/Auth (10.3.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 9.6.0)
-  - Firebase/CoreOnly (9.6.0):
-    - FirebaseCore (= 9.6.0)
-  - firebase_auth (3.11.2):
-    - Firebase/Auth (= 9.6.0)
+    - FirebaseAuth (~> 10.3.0)
+  - Firebase/CoreOnly (10.3.0):
+    - FirebaseCore (= 10.3.0)
+  - firebase_auth (4.2.6):
+    - Firebase/Auth (= 10.3.0)
     - firebase_core
     - Flutter
-  - firebase_core (1.24.0):
-    - Firebase/CoreOnly (= 9.6.0)
+  - firebase_core (2.5.0):
+    - Firebase/CoreOnly (= 10.3.0)
     - Flutter
-  - FirebaseAuth (9.6.0):
-    - FirebaseCore (~> 9.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.7)
-  - FirebaseCore (9.6.0):
-    - FirebaseCoreDiagnostics (~> 9.0)
-    - FirebaseCoreInternal (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (9.6.0):
-    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
-    - GoogleUtilities/Environment (~> 7.7)
-    - GoogleUtilities/Logger (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCoreInternal (9.6.0):
-    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+  - FirebaseAuth (10.3.0):
+    - FirebaseCore (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GTMSessionFetcher/Core (< 4.0, >= 2.1)
+  - FirebaseCore (10.3.0):
+    - FirebaseCoreInternal (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/Logger (~> 7.8)
+  - FirebaseCoreInternal (10.5.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - Flutter (1.0.0)
-  - flutter_line_sdk (2.3.0):
+  - flutter_line_sdk (2.3.1):
     - Flutter
     - LineSDKSwift (~> 5.3)
   - google_sign_in_ios (0.0.1):
     - Flutter
     - GoogleSignIn (~> 6.2)
-  - GoogleDataTransport (9.2.0):
-    - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
   - GoogleSignIn (6.2.4):
     - AppAuth (~> 1.5)
     - GTMAppAuth (~> 1.3)
     - GTMSessionFetcher/Core (< 3.0, >= 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.10.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.11.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.10.0):
+  - GoogleUtilities/Environment (7.11.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.10.0):
+  - GoogleUtilities/Logger (7.11.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.10.0):
+  - GoogleUtilities/Network (7.11.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.10.0)"
-  - GoogleUtilities/Reachability (7.10.0):
+  - "GoogleUtilities/NSData+zlib (7.11.0)"
+  - GoogleUtilities/Reachability (7.11.0):
     - GoogleUtilities/Logger
   - GTMAppAuth (1.3.1):
     - AppAuth/Core (~> 1.6)
@@ -74,17 +64,14 @@ PODS:
   - LineSDKSwift (5.9.0):
     - LineSDKSwift/Core (= 5.9.0)
   - LineSDKSwift/Core (5.9.0)
-  - nanopb (2.30909.0):
-    - nanopb/decode (= 2.30909.0)
-    - nanopb/encode (= 2.30909.0)
-  - nanopb/decode (2.30909.0)
-  - nanopb/encode (2.30909.0)
-  - path_provider_ios (0.0.1):
+  - path_provider_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
   - PromisesObjC (2.1.1)
   - ReachabilitySwift (5.0.0)
-  - shared_preferences_ios (0.0.1):
+  - shared_preferences_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
@@ -93,8 +80,8 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_line_sdk (from `.symlinks/plugins/flutter_line_sdk/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/ios`)
-  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
-  - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
 
 SPEC REPOS:
   trunk:
@@ -102,15 +89,12 @@ SPEC REPOS:
     - Firebase
     - FirebaseAuth
     - FirebaseCore
-    - FirebaseCoreDiagnostics
     - FirebaseCoreInternal
-    - GoogleDataTransport
     - GoogleSignIn
     - GoogleUtilities
     - GTMAppAuth
     - GTMSessionFetcher
     - LineSDKSwift
-    - nanopb
     - PromisesObjC
     - ReachabilitySwift
 
@@ -127,35 +111,32 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_line_sdk/ios"
   google_sign_in_ios:
     :path: ".symlinks/plugins/google_sign_in_ios/ios"
-  path_provider_ios:
-    :path: ".symlinks/plugins/path_provider_ios/ios"
-  shared_preferences_ios:
-    :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/ios"
 
 SPEC CHECKSUMS:
   AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
   connectivity_plus: 413a8857dd5d9f1c399a39130850d02fe0feaf7e
-  Firebase: 5ae8b7cf8efce559a653aef0ad95bab3f427c351
-  firebase_auth: 07a4db69cfa447ac42cb7faa560fc100708b707c
-  firebase_core: 7c28ecc1e5dd74e03829ac3e9ff5ba3314e737a9
-  FirebaseAuth: e4a5d3c36e778e41141b91cc861103a441d80bcc
-  FirebaseCore: 2082fffcd855f95f883c0a1641133eb9bbe76d40
-  FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
-  FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
+  Firebase: f92fc551ead69c94168d36c2b26188263860acd9
+  firebase_auth: b196f91b4f7c6d72015c3c12aaa82eb6972b2c2c
+  firebase_core: f95c8bbe65213d406d592573ad42a12d64849cb8
+  FirebaseAuth: 0e415d29d846c1dce2fb641e46f35e9888d9bec6
+  FirebaseCore: 988754646ab3bd4bdcb740f1bfe26b9f6c0d5f2a
+  FirebaseCoreInternal: e463f41bb935cd049505bf7e9a5bdd7dcea90df6
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  flutter_line_sdk: ffbd219457120ca500b4fba2a5fd818dee21a17a
+  flutter_line_sdk: a86e7072a47b7fe0e251c11354c5b7dd04d9947b
   google_sign_in_ios: 4f85eb9f937450765c8573bb85fd8cd6a5af675c
-  GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
-  GoogleUtilities: bad72cb363809015b1f7f19beb1f1cd23c589f95
+  GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
   LineSDKSwift: 97d6306ca17ae41520f29eb5dff4077dd81f08b2
-  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
-  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  shared_preferences_foundation: 297b3ebca31b34ec92be11acd7fb0ba932c822ca
 
 PODFILE CHECKSUM: 7368163408c647b7eb699d0d788ba6718e18fb8d
 

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -31,7 +31,7 @@ class _SystemHash {
   }
 }
 
-String $tripControllerHash() => r'ecb9d08395accfaf9687b15c2b145bb9a666d1d1';
+String _$tripControllerHash() => r'ecb9d08395accfaf9687b15c2b145bb9a666d1d1';
 
 /// See also [tripController].
 final tripControllerProvider = AutoDisposeProvider<TripController>(
@@ -39,6 +39,6 @@ final tripControllerProvider = AutoDisposeProvider<TripController>(
   name: r'tripControllerProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : $tripControllerHash,
+      : _$tripControllerHash,
 );
 typedef TripControllerRef = AutoDisposeProviderRef<TripController>;

--- a/lib/features/trips/data/models/fetch_trip_member_response.dart
+++ b/lib/features/trips/data/models/fetch_trip_member_response.dart
@@ -8,7 +8,7 @@ part 'fetch_trip_member_response.g.dart';
 class FetchTripMemberResponse with _$FetchTripMemberResponse {
   const factory FetchTripMemberResponse({
     required bool isHost,
-    required GetUserResponse user,
+    required GetUserResponse member,
   }) = _FetchTripMemberResponse;
 
   factory FetchTripMemberResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/trips/data/models/fetch_trip_member_response.dart
+++ b/lib/features/trips/data/models/fetch_trip_member_response.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:trip_app_nativeapp/features/user/data/models/get_user_response.dart';
+
+part 'fetch_trip_member_response.freezed.dart';
+part 'fetch_trip_member_response.g.dart';
+
+@Freezed(copyWith: false)
+class FetchTripMemberResponse with _$FetchTripMemberResponse {
+  const factory FetchTripMemberResponse({
+    required bool isHost,
+    required GetUserResponse user,
+  }) = _FetchTripMemberResponse;
+
+  factory FetchTripMemberResponse.fromJson(Map<String, dynamic> json) =>
+      _$FetchTripMemberResponseFromJson(json);
+}

--- a/lib/features/trips/data/models/fetch_trip_member_response.freezed.dart
+++ b/lib/features/trips/data/models/fetch_trip_member_response.freezed.dart
@@ -22,7 +22,7 @@ FetchTripMemberResponse _$FetchTripMemberResponseFromJson(
 /// @nodoc
 mixin _$FetchTripMemberResponse {
   bool get isHost => throw _privateConstructorUsedError;
-  GetUserResponse get user => throw _privateConstructorUsedError;
+  GetUserResponse get member => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
@@ -30,7 +30,8 @@ mixin _$FetchTripMemberResponse {
 /// @nodoc
 @JsonSerializable()
 class _$_FetchTripMemberResponse implements _FetchTripMemberResponse {
-  const _$_FetchTripMemberResponse({required this.isHost, required this.user});
+  const _$_FetchTripMemberResponse(
+      {required this.isHost, required this.member});
 
   factory _$_FetchTripMemberResponse.fromJson(Map<String, dynamic> json) =>
       _$$_FetchTripMemberResponseFromJson(json);
@@ -38,11 +39,11 @@ class _$_FetchTripMemberResponse implements _FetchTripMemberResponse {
   @override
   final bool isHost;
   @override
-  final GetUserResponse user;
+  final GetUserResponse member;
 
   @override
   String toString() {
-    return 'FetchTripMemberResponse(isHost: $isHost, user: $user)';
+    return 'FetchTripMemberResponse(isHost: $isHost, member: $member)';
   }
 
   @override
@@ -51,12 +52,12 @@ class _$_FetchTripMemberResponse implements _FetchTripMemberResponse {
         (other.runtimeType == runtimeType &&
             other is _$_FetchTripMemberResponse &&
             (identical(other.isHost, isHost) || other.isHost == isHost) &&
-            (identical(other.user, user) || other.user == user));
+            (identical(other.member, member) || other.member == member));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, isHost, user);
+  int get hashCode => Object.hash(runtimeType, isHost, member);
 
   @override
   Map<String, dynamic> toJson() {
@@ -69,7 +70,7 @@ class _$_FetchTripMemberResponse implements _FetchTripMemberResponse {
 abstract class _FetchTripMemberResponse implements FetchTripMemberResponse {
   const factory _FetchTripMemberResponse(
       {required final bool isHost,
-      required final GetUserResponse user}) = _$_FetchTripMemberResponse;
+      required final GetUserResponse member}) = _$_FetchTripMemberResponse;
 
   factory _FetchTripMemberResponse.fromJson(Map<String, dynamic> json) =
       _$_FetchTripMemberResponse.fromJson;
@@ -77,5 +78,5 @@ abstract class _FetchTripMemberResponse implements FetchTripMemberResponse {
   @override
   bool get isHost;
   @override
-  GetUserResponse get user;
+  GetUserResponse get member;
 }

--- a/lib/features/trips/data/models/fetch_trip_member_response.freezed.dart
+++ b/lib/features/trips/data/models/fetch_trip_member_response.freezed.dart
@@ -1,0 +1,81 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'fetch_trip_member_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+FetchTripMemberResponse _$FetchTripMemberResponseFromJson(
+    Map<String, dynamic> json) {
+  return _FetchTripMemberResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$FetchTripMemberResponse {
+  bool get isHost => throw _privateConstructorUsedError;
+  GetUserResponse get user => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_FetchTripMemberResponse implements _FetchTripMemberResponse {
+  const _$_FetchTripMemberResponse({required this.isHost, required this.user});
+
+  factory _$_FetchTripMemberResponse.fromJson(Map<String, dynamic> json) =>
+      _$$_FetchTripMemberResponseFromJson(json);
+
+  @override
+  final bool isHost;
+  @override
+  final GetUserResponse user;
+
+  @override
+  String toString() {
+    return 'FetchTripMemberResponse(isHost: $isHost, user: $user)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_FetchTripMemberResponse &&
+            (identical(other.isHost, isHost) || other.isHost == isHost) &&
+            (identical(other.user, user) || other.user == user));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, isHost, user);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_FetchTripMemberResponseToJson(
+      this,
+    );
+  }
+}
+
+abstract class _FetchTripMemberResponse implements FetchTripMemberResponse {
+  const factory _FetchTripMemberResponse(
+      {required final bool isHost,
+      required final GetUserResponse user}) = _$_FetchTripMemberResponse;
+
+  factory _FetchTripMemberResponse.fromJson(Map<String, dynamic> json) =
+      _$_FetchTripMemberResponse.fromJson;
+
+  @override
+  bool get isHost;
+  @override
+  GetUserResponse get user;
+}

--- a/lib/features/trips/data/models/fetch_trip_member_response.g.dart
+++ b/lib/features/trips/data/models/fetch_trip_member_response.g.dart
@@ -16,7 +16,7 @@ _$_FetchTripMemberResponse _$$_FetchTripMemberResponseFromJson(
       ($checkedConvert) {
         final val = _$_FetchTripMemberResponse(
           isHost: $checkedConvert('is_host', (v) => v as bool),
-          user: $checkedConvert('user',
+          member: $checkedConvert('member',
               (v) => GetUserResponse.fromJson(v as Map<String, dynamic>)),
         );
         return val;
@@ -28,5 +28,5 @@ Map<String, dynamic> _$$_FetchTripMemberResponseToJson(
         _$_FetchTripMemberResponse instance) =>
     <String, dynamic>{
       'is_host': instance.isHost,
-      'user': instance.user,
+      'member': instance.member,
     };

--- a/lib/features/trips/data/models/fetch_trip_member_response.g.dart
+++ b/lib/features/trips/data/models/fetch_trip_member_response.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
+part of 'fetch_trip_member_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_FetchTripMemberResponse _$$_FetchTripMemberResponseFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$_FetchTripMemberResponse',
+      json,
+      ($checkedConvert) {
+        final val = _$_FetchTripMemberResponse(
+          isHost: $checkedConvert('is_host', (v) => v as bool),
+          user: $checkedConvert('user',
+              (v) => GetUserResponse.fromJson(v as Map<String, dynamic>)),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'isHost': 'is_host'},
+    );
+
+Map<String, dynamic> _$$_FetchTripMemberResponseToJson(
+        _$_FetchTripMemberResponse instance) =>
+    <String, dynamic>{
+      'is_host': instance.isHost,
+      'user': instance.user,
+    };

--- a/lib/features/trips/data/models/fetch_trip_response.dart
+++ b/lib/features/trips/data/models/fetch_trip_response.dart
@@ -1,5 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:trip_app_nativeapp/core/json_converter/date_converter.dart';
+import 'package:trip_app_nativeapp/core/json_converter/datetime_converter.dart';
 import 'package:trip_app_nativeapp/features/trips/data/models/fetch_trip_member_response.dart';
 
 part 'fetch_trip_response.freezed.dart';

--- a/lib/features/trips/data/models/fetch_trip_response.dart
+++ b/lib/features/trips/data/models/fetch_trip_response.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:trip_app_nativeapp/core/json_converter/date_converter.dart';
+import 'package:trip_app_nativeapp/features/trips/data/models/fetch_trip_member_response.dart';
+
+part 'fetch_trip_response.freezed.dart';
+part 'fetch_trip_response.g.dart';
+
+@freezed
+class FetchTripResponse with _$FetchTripResponse {
+  const factory FetchTripResponse({
+    required int id,
+    required String name,
+    required List<FetchTripMemberResponse> members,
+    @DateConverter() required DateTime fromDate,
+    @DateConverter() required DateTime endDate,
+  }) = _FetchTripResponse;
+
+  factory FetchTripResponse.fromJson(Map<String, dynamic> json) =>
+      _$FetchTripResponseFromJson(json);
+}

--- a/lib/features/trips/data/models/fetch_trip_response.freezed.dart
+++ b/lib/features/trips/data/models/fetch_trip_response.freezed.dart
@@ -1,0 +1,251 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'fetch_trip_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+FetchTripResponse _$FetchTripResponseFromJson(Map<String, dynamic> json) {
+  return _FetchTripResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$FetchTripResponse {
+  int get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  List<FetchTripMemberResponse> get members =>
+      throw _privateConstructorUsedError;
+  @DateConverter()
+  DateTime get fromDate => throw _privateConstructorUsedError;
+  @DateConverter()
+  DateTime get endDate => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $FetchTripResponseCopyWith<FetchTripResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $FetchTripResponseCopyWith<$Res> {
+  factory $FetchTripResponseCopyWith(
+          FetchTripResponse value, $Res Function(FetchTripResponse) then) =
+      _$FetchTripResponseCopyWithImpl<$Res, FetchTripResponse>;
+  @useResult
+  $Res call(
+      {int id,
+      String name,
+      List<FetchTripMemberResponse> members,
+      @DateConverter() DateTime fromDate,
+      @DateConverter() DateTime endDate});
+}
+
+/// @nodoc
+class _$FetchTripResponseCopyWithImpl<$Res, $Val extends FetchTripResponse>
+    implements $FetchTripResponseCopyWith<$Res> {
+  _$FetchTripResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? members = null,
+    Object? fromDate = null,
+    Object? endDate = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      members: null == members
+          ? _value.members
+          : members // ignore: cast_nullable_to_non_nullable
+              as List<FetchTripMemberResponse>,
+      fromDate: null == fromDate
+          ? _value.fromDate
+          : fromDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endDate: null == endDate
+          ? _value.endDate
+          : endDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_FetchTripResponseCopyWith<$Res>
+    implements $FetchTripResponseCopyWith<$Res> {
+  factory _$$_FetchTripResponseCopyWith(_$_FetchTripResponse value,
+          $Res Function(_$_FetchTripResponse) then) =
+      __$$_FetchTripResponseCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      String name,
+      List<FetchTripMemberResponse> members,
+      @DateConverter() DateTime fromDate,
+      @DateConverter() DateTime endDate});
+}
+
+/// @nodoc
+class __$$_FetchTripResponseCopyWithImpl<$Res>
+    extends _$FetchTripResponseCopyWithImpl<$Res, _$_FetchTripResponse>
+    implements _$$_FetchTripResponseCopyWith<$Res> {
+  __$$_FetchTripResponseCopyWithImpl(
+      _$_FetchTripResponse _value, $Res Function(_$_FetchTripResponse) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? members = null,
+    Object? fromDate = null,
+    Object? endDate = null,
+  }) {
+    return _then(_$_FetchTripResponse(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      members: null == members
+          ? _value._members
+          : members // ignore: cast_nullable_to_non_nullable
+              as List<FetchTripMemberResponse>,
+      fromDate: null == fromDate
+          ? _value.fromDate
+          : fromDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endDate: null == endDate
+          ? _value.endDate
+          : endDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_FetchTripResponse implements _FetchTripResponse {
+  const _$_FetchTripResponse(
+      {required this.id,
+      required this.name,
+      required final List<FetchTripMemberResponse> members,
+      @DateConverter() required this.fromDate,
+      @DateConverter() required this.endDate})
+      : _members = members;
+
+  factory _$_FetchTripResponse.fromJson(Map<String, dynamic> json) =>
+      _$$_FetchTripResponseFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final String name;
+  final List<FetchTripMemberResponse> _members;
+  @override
+  List<FetchTripMemberResponse> get members {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_members);
+  }
+
+  @override
+  @DateConverter()
+  final DateTime fromDate;
+  @override
+  @DateConverter()
+  final DateTime endDate;
+
+  @override
+  String toString() {
+    return 'FetchTripResponse(id: $id, name: $name, members: $members, fromDate: $fromDate, endDate: $endDate)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_FetchTripResponse &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other._members, _members) &&
+            (identical(other.fromDate, fromDate) ||
+                other.fromDate == fromDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name,
+      const DeepCollectionEquality().hash(_members), fromDate, endDate);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_FetchTripResponseCopyWith<_$_FetchTripResponse> get copyWith =>
+      __$$_FetchTripResponseCopyWithImpl<_$_FetchTripResponse>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_FetchTripResponseToJson(
+      this,
+    );
+  }
+}
+
+abstract class _FetchTripResponse implements FetchTripResponse {
+  const factory _FetchTripResponse(
+      {required final int id,
+      required final String name,
+      required final List<FetchTripMemberResponse> members,
+      @DateConverter() required final DateTime fromDate,
+      @DateConverter() required final DateTime endDate}) = _$_FetchTripResponse;
+
+  factory _FetchTripResponse.fromJson(Map<String, dynamic> json) =
+      _$_FetchTripResponse.fromJson;
+
+  @override
+  int get id;
+  @override
+  String get name;
+  @override
+  List<FetchTripMemberResponse> get members;
+  @override
+  @DateConverter()
+  DateTime get fromDate;
+  @override
+  @DateConverter()
+  DateTime get endDate;
+  @override
+  @JsonKey(ignore: true)
+  _$$_FetchTripResponseCopyWith<_$_FetchTripResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/trips/data/models/fetch_trip_response.g.dart
+++ b/lib/features/trips/data/models/fetch_trip_response.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
+part of 'fetch_trip_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_FetchTripResponse _$$_FetchTripResponseFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$_FetchTripResponse',
+      json,
+      ($checkedConvert) {
+        final val = _$_FetchTripResponse(
+          id: $checkedConvert('id', (v) => v as int),
+          name: $checkedConvert('name', (v) => v as String),
+          members: $checkedConvert(
+              'members',
+              (v) => (v as List<dynamic>)
+                  .map((e) => FetchTripMemberResponse.fromJson(
+                      e as Map<String, dynamic>))
+                  .toList()),
+          fromDate: $checkedConvert(
+              'from_date', (v) => const DateConverter().fromJson(v as String)),
+          endDate: $checkedConvert(
+              'end_date', (v) => const DateConverter().fromJson(v as String)),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'fromDate': 'from_date', 'endDate': 'end_date'},
+    );
+
+Map<String, dynamic> _$$_FetchTripResponseToJson(
+        _$_FetchTripResponse instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'members': instance.members,
+      'from_date': const DateConverter().toJson(instance.fromDate),
+      'end_date': const DateConverter().toJson(instance.endDate),
+    };

--- a/lib/features/trips/data/models/fetch_trips_response.dart
+++ b/lib/features/trips/data/models/fetch_trips_response.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:trip_app_nativeapp/features/trips/data/models/fetch_trip_response.dart';
+
+part 'fetch_trips_response.freezed.dart';
+part 'fetch_trips_response.g.dart';
+
+@freezed
+class FetchTripsResponse with _$FetchTripsResponse {
+  const factory FetchTripsResponse({
+    required List<FetchTripResponse> trips,
+  }) = _FetchTripsResponse;
+
+  factory FetchTripsResponse.fromJson(Map<String, dynamic> json) =>
+      _$FetchTripsResponseFromJson(json);
+}

--- a/lib/features/trips/data/models/fetch_trips_response.dart
+++ b/lib/features/trips/data/models/fetch_trips_response.dart
@@ -7,7 +7,7 @@ part 'fetch_trips_response.g.dart';
 @freezed
 class FetchTripsResponse with _$FetchTripsResponse {
   const factory FetchTripsResponse({
-    required List<FetchTripResponse> trips,
+    required List<FetchTripResponse> items,
   }) = _FetchTripsResponse;
 
   factory FetchTripsResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/trips/data/models/fetch_trips_response.freezed.dart
+++ b/lib/features/trips/data/models/fetch_trips_response.freezed.dart
@@ -1,0 +1,159 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'fetch_trips_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+FetchTripsResponse _$FetchTripsResponseFromJson(Map<String, dynamic> json) {
+  return _FetchTripsResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$FetchTripsResponse {
+  List<FetchTripResponse> get trips => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $FetchTripsResponseCopyWith<FetchTripsResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $FetchTripsResponseCopyWith<$Res> {
+  factory $FetchTripsResponseCopyWith(
+          FetchTripsResponse value, $Res Function(FetchTripsResponse) then) =
+      _$FetchTripsResponseCopyWithImpl<$Res, FetchTripsResponse>;
+  @useResult
+  $Res call({List<FetchTripResponse> trips});
+}
+
+/// @nodoc
+class _$FetchTripsResponseCopyWithImpl<$Res, $Val extends FetchTripsResponse>
+    implements $FetchTripsResponseCopyWith<$Res> {
+  _$FetchTripsResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? trips = null,
+  }) {
+    return _then(_value.copyWith(
+      trips: null == trips
+          ? _value.trips
+          : trips // ignore: cast_nullable_to_non_nullable
+              as List<FetchTripResponse>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_FetchTripsResponseCopyWith<$Res>
+    implements $FetchTripsResponseCopyWith<$Res> {
+  factory _$$_FetchTripsResponseCopyWith(_$_FetchTripsResponse value,
+          $Res Function(_$_FetchTripsResponse) then) =
+      __$$_FetchTripsResponseCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<FetchTripResponse> trips});
+}
+
+/// @nodoc
+class __$$_FetchTripsResponseCopyWithImpl<$Res>
+    extends _$FetchTripsResponseCopyWithImpl<$Res, _$_FetchTripsResponse>
+    implements _$$_FetchTripsResponseCopyWith<$Res> {
+  __$$_FetchTripsResponseCopyWithImpl(
+      _$_FetchTripsResponse _value, $Res Function(_$_FetchTripsResponse) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? trips = null,
+  }) {
+    return _then(_$_FetchTripsResponse(
+      trips: null == trips
+          ? _value._trips
+          : trips // ignore: cast_nullable_to_non_nullable
+              as List<FetchTripResponse>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_FetchTripsResponse implements _FetchTripsResponse {
+  const _$_FetchTripsResponse({required final List<FetchTripResponse> trips})
+      : _trips = trips;
+
+  factory _$_FetchTripsResponse.fromJson(Map<String, dynamic> json) =>
+      _$$_FetchTripsResponseFromJson(json);
+
+  final List<FetchTripResponse> _trips;
+  @override
+  List<FetchTripResponse> get trips {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_trips);
+  }
+
+  @override
+  String toString() {
+    return 'FetchTripsResponse(trips: $trips)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_FetchTripsResponse &&
+            const DeepCollectionEquality().equals(other._trips, _trips));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_trips));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_FetchTripsResponseCopyWith<_$_FetchTripsResponse> get copyWith =>
+      __$$_FetchTripsResponseCopyWithImpl<_$_FetchTripsResponse>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_FetchTripsResponseToJson(
+      this,
+    );
+  }
+}
+
+abstract class _FetchTripsResponse implements FetchTripsResponse {
+  const factory _FetchTripsResponse(
+      {required final List<FetchTripResponse> trips}) = _$_FetchTripsResponse;
+
+  factory _FetchTripsResponse.fromJson(Map<String, dynamic> json) =
+      _$_FetchTripsResponse.fromJson;
+
+  @override
+  List<FetchTripResponse> get trips;
+  @override
+  @JsonKey(ignore: true)
+  _$$_FetchTripsResponseCopyWith<_$_FetchTripsResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/trips/data/models/fetch_trips_response.freezed.dart
+++ b/lib/features/trips/data/models/fetch_trips_response.freezed.dart
@@ -20,7 +20,7 @@ FetchTripsResponse _$FetchTripsResponseFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$FetchTripsResponse {
-  List<FetchTripResponse> get trips => throw _privateConstructorUsedError;
+  List<FetchTripResponse> get items => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -34,7 +34,7 @@ abstract class $FetchTripsResponseCopyWith<$Res> {
           FetchTripsResponse value, $Res Function(FetchTripsResponse) then) =
       _$FetchTripsResponseCopyWithImpl<$Res, FetchTripsResponse>;
   @useResult
-  $Res call({List<FetchTripResponse> trips});
+  $Res call({List<FetchTripResponse> items});
 }
 
 /// @nodoc
@@ -50,12 +50,12 @@ class _$FetchTripsResponseCopyWithImpl<$Res, $Val extends FetchTripsResponse>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? trips = null,
+    Object? items = null,
   }) {
     return _then(_value.copyWith(
-      trips: null == trips
-          ? _value.trips
-          : trips // ignore: cast_nullable_to_non_nullable
+      items: null == items
+          ? _value.items
+          : items // ignore: cast_nullable_to_non_nullable
               as List<FetchTripResponse>,
     ) as $Val);
   }
@@ -69,7 +69,7 @@ abstract class _$$_FetchTripsResponseCopyWith<$Res>
       __$$_FetchTripsResponseCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({List<FetchTripResponse> trips});
+  $Res call({List<FetchTripResponse> items});
 }
 
 /// @nodoc
@@ -83,12 +83,12 @@ class __$$_FetchTripsResponseCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? trips = null,
+    Object? items = null,
   }) {
     return _then(_$_FetchTripsResponse(
-      trips: null == trips
-          ? _value._trips
-          : trips // ignore: cast_nullable_to_non_nullable
+      items: null == items
+          ? _value._items
+          : items // ignore: cast_nullable_to_non_nullable
               as List<FetchTripResponse>,
     ));
   }
@@ -97,22 +97,22 @@ class __$$_FetchTripsResponseCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$_FetchTripsResponse implements _FetchTripsResponse {
-  const _$_FetchTripsResponse({required final List<FetchTripResponse> trips})
-      : _trips = trips;
+  const _$_FetchTripsResponse({required final List<FetchTripResponse> items})
+      : _items = items;
 
   factory _$_FetchTripsResponse.fromJson(Map<String, dynamic> json) =>
       _$$_FetchTripsResponseFromJson(json);
 
-  final List<FetchTripResponse> _trips;
+  final List<FetchTripResponse> _items;
   @override
-  List<FetchTripResponse> get trips {
+  List<FetchTripResponse> get items {
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_trips);
+    return EqualUnmodifiableListView(_items);
   }
 
   @override
   String toString() {
-    return 'FetchTripsResponse(trips: $trips)';
+    return 'FetchTripsResponse(items: $items)';
   }
 
   @override
@@ -120,13 +120,13 @@ class _$_FetchTripsResponse implements _FetchTripsResponse {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_FetchTripsResponse &&
-            const DeepCollectionEquality().equals(other._trips, _trips));
+            const DeepCollectionEquality().equals(other._items, _items));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(_trips));
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_items));
 
   @JsonKey(ignore: true)
   @override
@@ -145,13 +145,13 @@ class _$_FetchTripsResponse implements _FetchTripsResponse {
 
 abstract class _FetchTripsResponse implements FetchTripsResponse {
   const factory _FetchTripsResponse(
-      {required final List<FetchTripResponse> trips}) = _$_FetchTripsResponse;
+      {required final List<FetchTripResponse> items}) = _$_FetchTripsResponse;
 
   factory _FetchTripsResponse.fromJson(Map<String, dynamic> json) =
       _$_FetchTripsResponse.fromJson;
 
   @override
-  List<FetchTripResponse> get trips;
+  List<FetchTripResponse> get items;
   @override
   @JsonKey(ignore: true)
   _$$_FetchTripsResponseCopyWith<_$_FetchTripsResponse> get copyWith =>

--- a/lib/features/trips/data/models/fetch_trips_response.g.dart
+++ b/lib/features/trips/data/models/fetch_trips_response.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
+part of 'fetch_trips_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_FetchTripsResponse _$$_FetchTripsResponseFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$_FetchTripsResponse',
+      json,
+      ($checkedConvert) {
+        final val = _$_FetchTripsResponse(
+          trips: $checkedConvert(
+              'trips',
+              (v) => (v as List<dynamic>)
+                  .map((e) =>
+                      FetchTripResponse.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$_FetchTripsResponseToJson(
+        _$_FetchTripsResponse instance) =>
+    <String, dynamic>{
+      'trips': instance.trips,
+    };

--- a/lib/features/trips/data/models/fetch_trips_response.g.dart
+++ b/lib/features/trips/data/models/fetch_trips_response.g.dart
@@ -15,8 +15,8 @@ _$_FetchTripsResponse _$$_FetchTripsResponseFromJson(
       json,
       ($checkedConvert) {
         final val = _$_FetchTripsResponse(
-          trips: $checkedConvert(
-              'trips',
+          items: $checkedConvert(
+              'items',
               (v) => (v as List<dynamic>)
                   .map((e) =>
                       FetchTripResponse.fromJson(e as Map<String, dynamic>))
@@ -29,5 +29,5 @@ _$_FetchTripsResponse _$$_FetchTripsResponseFromJson(
 Map<String, dynamic> _$$_FetchTripsResponseToJson(
         _$_FetchTripsResponse instance) =>
     <String, dynamic>{
-      'trips': instance.trips,
+      'items': instance.items,
     };

--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -72,6 +72,9 @@ class TripRepository implements TripRepositoryInterface {
       title: tripRes.name,
       fromDate: tripRes.fromDate,
       endDate: tripRes.endDate,
+      members: [
+        // post のレスポンスにメンバー情報は含まれないので一旦空配列を入れておく
+      ],
     );
   }
 
@@ -112,6 +115,9 @@ class TripRepository implements TripRepositoryInterface {
         title: invitationRes.trip.name,
         fromDate: invitationRes.trip.fromDate,
         endDate: invitationRes.trip.endDate,
+        members: [
+          // 招待レスポンスにメンバー情報は含まれないので一旦空配列を入れておく
+        ],
       ),
       invitationUserName: invitationRes.invitationUser.name,
       invitationNum: invitationNum,

--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -70,16 +70,16 @@ class TripRepository implements TripRepositoryInterface {
     final res = await privateV1Client.get('/users/$userId$_basePath');
     final tripsRes = FetchTripsResponse.fromJson(res.data);
     final trips = <Trip>[];
-    for (final trip in tripsRes.trips) {
+    for (final trip in tripsRes.items) {
       final members = <TripMember>[];
-      for (final member in trip.members) {
+      for (final memberRes in trip.members) {
         members.add(
           TripMember.joined(
-            isHost: member.isHost,
+            isHost: memberRes.isHost,
             user: AppUser(
-              id: member.user.id,
-              name: member.user.name,
-              email: member.user.email,
+              id: memberRes.member.id,
+              name: memberRes.member.name,
+              email: memberRes.member.email,
             ),
           ),
         );

--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -69,30 +69,26 @@ class TripRepository implements TripRepositoryInterface {
   Future<List<Trip>> fetchTripsByUserId(int userId) async {
     final res = await privateV1Client.get('/users/$userId$_basePath');
     final tripsRes = FetchTripsResponse.fromJson(res.data);
-    final trips = <Trip>[];
-    for (final trip in tripsRes.items) {
-      final members = <TripMember>[];
-      for (final memberRes in trip.members) {
-        members.add(
-          TripMember.joined(
-            isHost: memberRes.isHost,
-            user: AppUser(
-              id: memberRes.member.id,
-              name: memberRes.member.name,
-              email: memberRes.member.email,
-            ),
+    return tripsRes.items
+        .map(
+          (tripRes) => Trip.createExistingTrip(
+            title: tripRes.name,
+            fromDate: tripRes.fromDate,
+            endDate: tripRes.endDate,
+            members: tripRes.members
+                .map(
+                  (memberRes) => TripMember.joined(
+                    isHost: memberRes.isHost,
+                    user: AppUser(
+                      id: memberRes.member.id,
+                      name: memberRes.member.name,
+                      email: memberRes.member.email,
+                    ),
+                  ),
+                )
+                .toList(),
           ),
-        );
-      }
-      trips.add(
-        Trip.createExistingTrip(
-          title: trip.name,
-          fromDate: trip.fromDate,
-          endDate: trip.endDate,
-          members: members,
-        ),
-      );
-    }
-    return trips;
+        )
+        .toList();
   }
 }

--- a/lib/features/trips/data/repositories/trip_repository.g.dart
+++ b/lib/features/trips/data/repositories/trip_repository.g.dart
@@ -31,7 +31,7 @@ class _SystemHash {
   }
 }
 
-String $tripRepositoryHash() => r'efd2fdd05eebdcae3167e10a504d71c811c9ebf2';
+String _$tripRepositoryHash() => r'efd2fdd05eebdcae3167e10a504d71c811c9ebf2';
 
 /// See also [tripRepository].
 final tripRepositoryProvider = AutoDisposeProvider<TripRepositoryInterface>(
@@ -39,6 +39,6 @@ final tripRepositoryProvider = AutoDisposeProvider<TripRepositoryInterface>(
   name: r'tripRepositoryProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : $tripRepositoryHash,
+      : _$tripRepositoryHash,
 );
 typedef TripRepositoryRef = AutoDisposeProviderRef<TripRepositoryInterface>;

--- a/lib/features/trips/domain/entity/trip/trip.dart
+++ b/lib/features/trips/domain/entity/trip/trip.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_member.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_period.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_title.dart';
 
@@ -9,6 +10,9 @@ class Trip with _$Trip {
   const factory Trip({
     required TripTitle title,
     required TripPeriod tripPeriod,
+
+    /// 新規作成時はメンバーがいないので null 許容
+    List<TripMember>? members,
   }) = _Trip;
 
   /// 新規作成時のfactory関数
@@ -32,6 +36,7 @@ class Trip with _$Trip {
     required String title,
     required DateTime fromDate,
     required DateTime endDate,
+    List<TripMember>? members,
   }) {
     return Trip(
       title: TripTitle(value: title),
@@ -39,6 +44,7 @@ class Trip with _$Trip {
         fromDate: fromDate,
         endDate: endDate,
       ),
+      members: members,
     );
   }
 }

--- a/lib/features/trips/domain/entity/trip/trip.dart
+++ b/lib/features/trips/domain/entity/trip/trip.dart
@@ -36,7 +36,7 @@ class Trip with _$Trip {
     required String title,
     required DateTime fromDate,
     required DateTime endDate,
-    List<TripMember>? members,
+    required List<TripMember> members,
   }) {
     return Trip(
       title: TripTitle(value: title),

--- a/lib/features/trips/domain/entity/trip/trip.freezed.dart
+++ b/lib/features/trips/domain/entity/trip/trip.freezed.dart
@@ -18,21 +18,40 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$Trip {
   TripTitle get title => throw _privateConstructorUsedError;
   TripPeriod get tripPeriod => throw _privateConstructorUsedError;
+
+  /// 新規作成時はメンバーがいないので null 許容
+  List<TripMember>? get members => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 
 class _$_Trip implements _Trip {
-  const _$_Trip({required this.title, required this.tripPeriod});
+  const _$_Trip(
+      {required this.title,
+      required this.tripPeriod,
+      final List<TripMember>? members})
+      : _members = members;
 
   @override
   final TripTitle title;
   @override
   final TripPeriod tripPeriod;
 
+  /// 新規作成時はメンバーがいないので null 許容
+  final List<TripMember>? _members;
+
+  /// 新規作成時はメンバーがいないので null 許容
+  @override
+  List<TripMember>? get members {
+    final value = _members;
+    if (value == null) return null;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
   @override
   String toString() {
-    return 'Trip(title: $title, tripPeriod: $tripPeriod)';
+    return 'Trip(title: $title, tripPeriod: $tripPeriod, members: $members)';
   }
 
   @override
@@ -42,20 +61,27 @@ class _$_Trip implements _Trip {
             other is _$_Trip &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.tripPeriod, tripPeriod) ||
-                other.tripPeriod == tripPeriod));
+                other.tripPeriod == tripPeriod) &&
+            const DeepCollectionEquality().equals(other._members, _members));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, title, tripPeriod);
+  int get hashCode => Object.hash(runtimeType, title, tripPeriod,
+      const DeepCollectionEquality().hash(_members));
 }
 
 abstract class _Trip implements Trip {
   const factory _Trip(
       {required final TripTitle title,
-      required final TripPeriod tripPeriod}) = _$_Trip;
+      required final TripPeriod tripPeriod,
+      final List<TripMember>? members}) = _$_Trip;
 
   @override
   TripTitle get title;
   @override
   TripPeriod get tripPeriod;
+  @override
+
+  /// 新規作成時はメンバーがいないので null 許容
+  List<TripMember>? get members;
 }

--- a/lib/features/trips/domain/entity/trip/trip_member.dart
+++ b/lib/features/trips/domain/entity/trip/trip_member.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:trip_app_nativeapp/features/user/domain/entity/app_user.dart';
+
+part 'trip_member.freezed.dart';
+
+@Freezed(copyWith: false, fromJson: false, toJson: false)
+class TripMember with _$TripMember {
+  /// 参加済みのメンバーの factory 関数
+  const factory TripMember.joined({
+    required bool isHost,
+    required AppUser user,
+  }) = JoinedTripMember;
+}

--- a/lib/features/trips/domain/entity/trip/trip_member.freezed.dart
+++ b/lib/features/trips/domain/entity/trip/trip_member.freezed.dart
@@ -1,0 +1,148 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'trip_member.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$TripMember {
+  bool get isHost => throw _privateConstructorUsedError;
+  AppUser get user => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(bool isHost, AppUser user) joined,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(bool isHost, AppUser user)? joined,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(bool isHost, AppUser user)? joined,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(JoinedTripMember value) joined,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(JoinedTripMember value)? joined,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(JoinedTripMember value)? joined,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+
+class _$JoinedTripMember implements JoinedTripMember {
+  const _$JoinedTripMember({required this.isHost, required this.user});
+
+  @override
+  final bool isHost;
+  @override
+  final AppUser user;
+
+  @override
+  String toString() {
+    return 'TripMember.joined(isHost: $isHost, user: $user)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$JoinedTripMember &&
+            (identical(other.isHost, isHost) || other.isHost == isHost) &&
+            (identical(other.user, user) || other.user == user));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, isHost, user);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(bool isHost, AppUser user) joined,
+  }) {
+    return joined(isHost, user);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(bool isHost, AppUser user)? joined,
+  }) {
+    return joined?.call(isHost, user);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(bool isHost, AppUser user)? joined,
+    required TResult orElse(),
+  }) {
+    if (joined != null) {
+      return joined(isHost, user);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(JoinedTripMember value) joined,
+  }) {
+    return joined(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(JoinedTripMember value)? joined,
+  }) {
+    return joined?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(JoinedTripMember value)? joined,
+    required TResult orElse(),
+  }) {
+    if (joined != null) {
+      return joined(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class JoinedTripMember implements TripMember {
+  const factory JoinedTripMember(
+      {required final bool isHost,
+      required final AppUser user}) = _$JoinedTripMember;
+
+  @override
+  bool get isHost;
+  @override
+  AppUser get user;
+}

--- a/lib/features/trips/domain/interactor/trip_interactor.g.dart
+++ b/lib/features/trips/domain/interactor/trip_interactor.g.dart
@@ -31,7 +31,7 @@ class _SystemHash {
   }
 }
 
-String $tripInteractorHash() => r'a652d163a62d0bf37feea5675ea5e67ddca1aa23';
+String _$tripInteractorHash() => r'a652d163a62d0bf37feea5675ea5e67ddca1aa23';
 
 /// See also [tripInteractor].
 final tripInteractorProvider = AutoDisposeProvider<TripInteractor>(
@@ -39,6 +39,6 @@ final tripInteractorProvider = AutoDisposeProvider<TripInteractor>(
   name: r'tripInteractorProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : $tripInteractorHash,
+      : _$tripInteractorHash,
 );
 typedef TripInteractorRef = AutoDisposeProviderRef<TripInteractor>;

--- a/lib/features/trips/domain/repositories/trip_repository_interface.dart
+++ b/lib/features/trips/domain/repositories/trip_repository_interface.dart
@@ -4,6 +4,11 @@ import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_invita
 abstract class TripRepositoryInterface {
   /// 旅データ作成
   Future<Trip> createTrip(Trip trip);
+
+  /// 旅データ取得
+  /// ユーザーが参加している旅データ一覧を取得する
+  Future<List<Trip>> fetchTripsByUserId(int userId);
+
   /// 招待状作成
   Future<GeneratedTripInvitation> invite(
     NewTripInvitation invitation,

--- a/lib/router.g.dart
+++ b/lib/router.g.dart
@@ -31,13 +31,13 @@ class _SystemHash {
   }
 }
 
-String $routerHash() => r'f2ed8408dd5fb9ee574d55575b9ceef174cecd0f';
+String _$routerHash() => r'f2ed8408dd5fb9ee574d55575b9ceef174cecd0f';
 
 /// See also [router].
 final routerProvider = AutoDisposeProvider<GoRouter>(
   router,
   name: r'routerProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $routerHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$routerHash,
 );
 typedef RouterRef = AutoDisposeProviderRef<GoRouter>;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,376 +5,343 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "4897882604d919befd350648c7f91926a9d5de99e67b455bf0917cc2362f4bb8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "47.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "2f428053492f92303e42c9afa8e3a78ad1886760e7b594e2b5a6b6ee47376360"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.13"
+  adaptive_number:
+    dependency: transitive
+    description:
+      name: adaptive_number
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "690e335554a8385bc9d787117d9eb52c0c03ee207a607e593de3c9d71b1cfe80"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.7.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      sha256: "793964beb8e297995714326628881437d4211f10fc8843534bab54129cd896ee"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.6"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: b003c3098049a51720352d219b0bb5f219b60fbfb68e7a4748139a06a5676515
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.10.0"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "5b7355c14258f5e7df24bad1566f7b991de3e54aeacfb94e1a65e5233d9739c1"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "687cf90a3951affac1bd5f9ecb5e3e90b60487f3d9cdc359bb310f8876bb02a6"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "93f05c041932674be039b0a2323d6cf57e5f2bbf884a3c0382f9e53fc45ebace"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "7.2.7"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      sha256: d7a9cd57c215bdf8d502772447aa6b52a8ab3f956d25d5fdea6ef1df2d2dad60
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.4.1"
+    version: "8.4.3"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "02ce3596b459c666530f045ad6f96209474e8fee6e4855940a3cee65fb872ec5"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   color:
     dependency: transitive
     description:
       name: color
-      sha256: ddcdf1b3badd7008233f5acffaf20ca9f5dc2cd0172b75f68f24526a5f5725cb
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
   connectivity_plus:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "745ebcccb1ef73768386154428a55250bc8d44059c19fd27aecda2a6dc013a22"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: b8795b9238bf83b64375f63492034cb3d8e222af4d9ce59dda085edf038fa06f
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: "961c4aebd27917269b1896382c7cb1b1ba81629ba669ba09c27a7e5710ec9040"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
   dart_jsonwebtoken:
     dependency: transitive
     description:
       name: dart_jsonwebtoken
-      sha256: c8c48c292732491c52fbf68727baa162bb95f5409823b08b9e52f9ff796b8bcf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.7.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.4"
   dartx:
     dependency: transitive
     description:
       name: dartx
-      sha256: "45d7176701f16c5a5e00a4798791c1964bc231491b879369c818dd9a9c764871"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   dbus:
     dependency: transitive
     description:
       name: dbus
-      sha256: "6f07cba3f7b3448d42d015bfd3d53fe12e5b36da2423f23838efc1d5fb31a263"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.8"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "7d328c4d898a61efc3cd93655a0955858e29a0aa647f0f9e02d59b3bb275e2e8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.6"
   dotenv:
     dependency: transitive
     description:
       name: dotenv
-      sha256: "301007cddf9995f8e4430d2f4840045dfbd57a5720b1a88ecd4ff9085ce2be79"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.1.0"
+  ed25519_edwards:
+    dependency: transitive
+    description:
+      name: ed25519_edwards
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.1"
   envied:
     dependency: transitive
     description:
       name: envied
-      sha256: "919178d93236febd250d09acc78a2e182da2c062bf8902555e6ec7828b4c2bc0"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   envied_generator:
     dependency: "direct dev"
     description:
       name: envied_generator
-      sha256: "1d1264439857ca4b40f3b664b0c79d85b84c043358d1bdd92f3ea108fc1c47e6"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.3"
   equatable:
     dependency: transitive
     description:
       name: equatable
-      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.4"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: ca3034d35d6ca894487ec80aa1162a135fef7c5d0abef8154789cbeea3a6deaf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.6"
   firebase_auth_mocks:
     dependency: "direct main"
     description:
       name: firebase_auth_mocks
-      sha256: "2c34d97ddbe6c7259c19f477b6781197d5c647274bbb9bb9009a43af019dec16"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.3"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: ab20ecbc411726e139250a49fa03fe1ae0105fd990c5330b2a148ec08dfb140b
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.11.8"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: bbe4f4fffcc378ca05c3d8ff33853be86dd27d0fafc85a953acaf5190531b6f9
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "5.2.5"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "4f1d7c13a909e82ff026679c9b8493cdeb35a9c76bc46c42bf9e2240c9e57e80"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.5.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: b51257a8b4388565cd66062d727d3e60067b5f5cc3390eb0ecd20b8f97741bdb
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.5.3"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "839f1b48032a61962792cea1225fae030d4f27163867f181d6d2072dd40acbee"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   flutter:
@@ -386,72 +353,63 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_datetime_picker
-      sha256: "8e695c63c769350e541951227c2775190ec73ceda774a315b1dc9a99d5facfe5"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.1"
   flutter_dotenv:
     dependency: "direct main"
     description:
       name: flutter_dotenv
-      sha256: d9283d92059a22e9834bc0a31336658ffba77089fb6f3cc36751f1fc7c6661a3
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "5.0.2"
   flutter_gen:
     dependency: "direct main"
     description:
       name: flutter_gen
-      sha256: "0d7c1a97521b02ea28bc58a5714e909bb27fbe4efbb320b6925c22999416a7f0"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0+1"
+    version: "5.2.0"
   flutter_gen_core:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: "8c5edb4db82dadf0d343b1be8bc5e878b66500eb79a583723147b1efb5749ccb"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0+1"
+    version: "5.2.0"
   flutter_hooks:
     dependency: "direct main"
     description:
       name: flutter_hooks
-      sha256: "2b202559a4ed3656bbb7aae9d8b335fb0037b23acc7ae3f377d1ba0b95c21aec"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.18.5+1"
   flutter_line_sdk:
     dependency: "direct main"
     description:
       name: flutter_line_sdk
-      sha256: "28fa4b9874b19285332db45ef082c491bbdc2371c8951379a94091fd428e795e"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   flutter_riverpod:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: "371f6e8acb69dbe8aa3e0a50c8a65f8a9352b599134d585cc4923261cb5ae4d6"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   flutter_spinkit:
     dependency: "direct main"
     description:
       name: flutter_spinkit
-      sha256: "77a2117c0517ff909221f3160b8eb20052ab5216107581168af574ac1f05dff8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "5.1.0"
   flutter_test:
@@ -468,266 +426,233 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      sha256: "8f0ce0204bd0cafa8631536a6f3b7d05d9c16cdc6e8bd807843f917027c5cefd"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.2.1"
+    version: "10.4.0"
   freezed:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "4179d41127bc7a67dc3f58ceec1d22f1cdf10470653cb86eda2a63f81b4920c7"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.0"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "4f4a162323c86ffc1245765cfe138872b8f069deb42f7dbb36115fa27f31469b"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   gap:
     dependency: "direct main"
     description:
       name: gap
-      sha256: "17a51ee49227c32472473de8c65c8a22f7fb5afb13d6dc5367926096aa55f2d0"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: c51b4fdfee4d281f49b8c957f1add91b815473597f76bcf07377987f66a55729
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   go_router:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "8aa73f9372f2e50545c322a6f8605ab9702f82d7daf6991470a7f6602a379ea4"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.5"
+    version: "5.2.4"
   google_fonts:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "8f099045e2f2a30e4d4d0a35f40c6bc941a8f2ca0e10ad9d214ee9edd3f37483"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
   google_sign_in:
     dependency: "direct main"
     description:
       name: google_sign_in
-      sha256: d3e31052ce068d0fe2eb9975ee4409266a044592cf67737ec230be07343c6bdf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.2"
+    version: "5.4.4"
   google_sign_in_android:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: "25449f21c7c8c28520576cab82e58fbb33b11055ebf69189cf255e2611cac6da"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.6"
   google_sign_in_ios:
     dependency: transitive
     description:
       name: google_sign_in_ios
-      sha256: "673c0b07eb512ea7097df316a4706e6fe9ccef7c7c258761005e8aa420fe955f"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.5.0"
+    version: "5.5.1"
   google_sign_in_mocks:
     dependency: "direct dev"
     description:
       name: google_sign_in_mocks
-      sha256: "0824a33e14b4979a899423f59525a8cd9bd67b545917625567af52c48ae5d080"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
-      sha256: "61306213c76bb8170c3aa20017df296c0131c24d7f6c0cc7e2eeaeac34c9f457"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.0"
   google_sign_in_web:
     dependency: transitive
     description:
       name: google_sign_in_web
-      sha256: "5b35c221169a7b3e0fc15043ac09102ef542300ef92f2e1f05d5d8efde263af5"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.2"
+    version: "0.10.2+1"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.0"
   hooks_riverpod:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: "33b7f91a10d385e3b4e8aac60fe15711d7bf53d199cb672789b44623770ae7ae"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.5"
   http_mock_adapter:
     dependency: "direct dev"
     description:
       name: http_mock_adapter
-      sha256: "6fa1a00932a5758750f54c5594f8bf37393fe5ae86e49325281b5a9d99114f33"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.3"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: db3060f22889f3d9d55f6a217565486737037eec3609f7f3eca4d0c67ee0d8a0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "3520fa844009431b5d4491a5a778603520cdc399ab3406332dcc50f93547258c"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.7.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: f3c2c18a7889580f71926f30c1937727c8c7d4f3a435f8f5e8b0ddd25253ef5d
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.5.4"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5cfd6509652ff5e7fe149b6df4859e687fca9048437857cb2e65c8d780f396e3"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   logger:
     dependency: transitive
     description:
       name: logger
-      sha256: "5076f09225f91dc49289a4ccb92df2eeea9ea01cf7c26d49b3a1f04c6a49eec1"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   lottie:
     dependency: "direct main"
     description:
       name: lottie
-      sha256: "893da7a0022ec2fcaa616f34529a081f617e86cc501105b856e5a3184c58c7c2"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: dab22e92b41aa1255ea90ddc4bc2feaf35544fd0728e209638cad041a6e3928a
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   mock_exceptions:
     dependency: transitive
     description:
@@ -739,312 +664,259 @@ packages:
     dependency: "direct main"
     description:
       name: mockito
-      sha256: "2a8a17b82b1bde04d514e75d90d634a0ac23f6cb4991f6098009dd56836aeafe"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "5.3.2"
   mocktail:
     dependency: "direct main"
     description:
       name: mocktail
-      sha256: "80a996cd9a69284b3dc521ce185ffe9150cde69767c2d3a0720147d93c0cef53"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
   nil:
     dependency: "direct main"
     description:
       name: nil
-      sha256: ef05770c48942876d843bf6a4822d35e5da0ff893a61f1d5ad96d15c4a659136
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   nm:
     dependency: transitive
     description:
       name: nm
-      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
-      sha256: "050e8e85e4b7fecdf2bb3682c1c64c4887a183720c802d323de8a5fd76d372dd"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.12"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "4d5542667150f5b779ba411dd5dc0b674a85d1355e45bda2877e0e82f4ad08d8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.20"
-  path_provider_ios:
+    version: "2.0.22"
+  path_provider_foundation:
     dependency: transitive
     description:
-      name: path_provider_ios
-      sha256: "03d639406f5343478352433f00d3c4394d52dac8df3d847869c5e2333e0bbce8"
-      url: "https://pub.dev"
+      name: path_provider_foundation
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.1.1"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: ab0987bf95bc591da42dffb38c77398fc43309f0b9b894dcc5d6f40c4b26c379
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.7"
-  path_provider_macos:
-    dependency: transitive
-    description:
-      name: path_provider_macos
-      sha256: "2a97e7fbb7ae9dcd0dfc1220a78e9ec3e71da691912e617e8715ff2a13086ae8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.6"
+    version: "2.1.8"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: f0abc8ebd7253741f05488b4813d936b4d07c6bae3e86148a09e342ee4b08e76
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: bcabbe399d4042b8ee687e17548d5d3f527255253b4a639f5f8d2094a9c2b45c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "2ebb289dc4764ec397f5cd3ca9881c6d17196130a7d646ed022a0dd9c2e25a71"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.6.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.1"
   process:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "816c1a640e952d213ddd223b3e7aafae08cd9f8e1f6864eed304cc13b0272b07"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   quiver:
     dependency: transitive
     description:
       name: quiver
-      sha256: "93982981971e812c94d4a6fa3a57b89f9ec12b38b6380cd3c1370c3b01e4580e"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.1"
   riverpod:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "899cd0999b2f3b798349d9b5639cfea81d406c011bd914097145ff92e91b29f9"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "96f59467a2dd09939e55b7acaf7508381b8634c90a18bbe4212cad955d1925f7"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.1.1"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "20ba4262045ec5a3071bf79e9062034ec3b06d4f1e6ed5cc6a22f22bb3225386"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.6"
+    version: "1.1.1"
   roggle:
     dependency: "direct main"
     description:
       name: roggle
-      sha256: "9f2d45cc19dad2baa51f7d815983c93c5f99f7c2cb2c7ca95ee642689add6d93"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "76917b7d4b9526b2ba416808a7eb9fb2863c1a09cf63ec85f1453da240fa818a"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.15"
+    version: "2.0.17"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "3e128864b9cff21bdd5b3ad569953070a851d62901bee880bb052b1110b38007"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
-  shared_preferences_ios:
+    version: "2.0.15"
+  shared_preferences_foundation:
     dependency: transitive
     description:
-      name: shared_preferences_ios
-      sha256: "585a14cefec7da8c9c2fb8cd283a3bb726b4155c0952afe6a0caaa7b2272de34"
-      url: "https://pub.dev"
+      name: shared_preferences_foundation
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: "28aefc1261746e7bad3d09799496054beb84e8c4ffcdfed7734e17b4ada459a5"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
-  shared_preferences_macos:
-    dependency: transitive
-    description:
-      name: shared_preferences_macos
-      sha256: fbb94bf296576f49be37a1496d5951796211a8db0aa22cc0d68c46440dad808c
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.4"
+    version: "2.1.3"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: da9431745ede5ece47bc26d5d73a9d3c6936ef6945c101a5aca46f62e52c1cf3
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: a4b5bc37fe1b368bbc81f953197d55e12f49d0296e7e412dfe2d2d77d6929958
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.4"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: "97f7ab9a7da96d9cf19581f5de520ceb529548498bd6b5e0ccd02d68a0d15eba"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   sky_engine:
@@ -1056,224 +928,196 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "85f8c7d6425dff95475db618404732f034c87fe23efe05478cea50520a2517a3"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.5"
+    version: "1.2.6"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "3b67aade1d52416149c633ba1bb36df44d97c6b51830c2198e934e3fca87ca1f"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.3"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "490098075234dcedb83c5d949b4c93dad5e6b7702748de000be2b57b8e6b2427"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   state_notifier:
     dependency: transitive
     description:
       name: state_notifier
-      sha256: "8fe42610f179b843b12371e40db58c9444f8757f8b69d181c97e50787caed289"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.2+1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   test:
     dependency: transitive
     description:
       name: test
-      sha256: a5fcd2d25eeadbb6589e80198a47d6a464ba3e2049da473943b8af9797900c2d
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.22.0"
+    version: "1.21.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0ef9755ec6d746951ba0aabe62f874b707690b5ede0fecc818b138fcc9b14888"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.20"
+    version: "0.4.16"
   time:
     dependency: transitive
     description:
       name: time
-      sha256: "83427e11d9072e038364a5e4da559e85869b227cf699a541be0da74f14140124"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
   timing:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      sha256: "2469694ad079893e3b434a627970c33f2fa5adc46dfe03c9617546969a9a8afc"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   very_good_analysis:
     dependency: "direct dev"
     description:
       name: very_good_analysis
-      sha256: "4815adc7ded57657038d2bb2a7f332c50e3c8152f7d3c6acf8f6b7c0cc81e5e2"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: e42dfcc48f67618344da967b10f62de57e04bae01d9d3af4c2596f3712a88c99
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "1952a663c0e34fbde55916010d54bbb249bf5f2583113c497602f0ee01c6faa4"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: "11541eedefbcaec9de35aa82650b695297ce668662bbd6e3911a7fabdbde589f"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+2"
+    version: "1.0.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      sha256: ac0e3f4bf00ba2708c33fbabbbe766300e509f8c82dbd4ab6525039813f7e2fb
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
 sdks:

--- a/test/core/http/api_client/api_client_test.dart
+++ b/test/core/http/api_client/api_client_test.dart
@@ -10,84 +10,166 @@ import 'package:trip_app_nativeapp/core/http/api_client/api_destination.dart';
 import 'package:trip_app_nativeapp/core/http/api_client/dio/dio.dart';
 
 Future<void> main() async {
-  group(
-    'ApiClient test',
-    () {
-      late DioAdapter dioAdapter;
-      late ProviderContainer container;
+  group('ApiClient test', () {
+    late DioAdapter dioAdapter;
+    late ProviderContainer container;
 
-      const dummyEndpoint = '/dummy-endpoint';
+    const dummyEndpoint = '/dummy-endpoint';
 
-      setUp(
-        () {
-          final dio = Dio(
-            BaseOptions(validateStatus: (status) => true),
-          );
-          dioAdapter = DioAdapter(dio: dio);
-          container = ProviderContainer(
-            overrides: [
-              dioProvider(ApiDestination.privateTripAppV1)
-                  .overrideWithValue(dio),
-            ],
-          );
-        },
-      );
+    setUp(
+      () {
+        final dio = Dio(
+          BaseOptions(validateStatus: (status) => true),
+        );
+        dioAdapter = DioAdapter(dio: dio);
+        container = ProviderContainer(
+          overrides: [
+            dioProvider(ApiDestination.privateTripAppV1).overrideWithValue(dio),
+          ],
+        );
+      },
+    );
 
-      test(
-        'post 正常系',
-        () async {
-          const testRequest = <String, dynamic>{
-            'data': <String, dynamic>{
+    group(
+      'get',
+      () {
+        test(
+          '正常系',
+          () async {
+            const testResponse = {
+              'data': [
+                {
+                  'id': 1,
+                  'name': 'Bob',
+                },
+                {
+                  'id': 2,
+                  'name': 'John',
+                },
+              ],
+            };
+
+            dioAdapter.onGet(
+              dummyEndpoint,
+              (server) => server.reply(
+                200,
+                testResponse,
+              ),
+            );
+
+            final response =
+                await container.read(privateTripAppV1ClientProvider).get(
+                      dummyEndpoint,
+                    );
+
+            expect(
+              response.data['items'],
+              testResponse['data'],
+              reason: '''
+                      レスポンスデータが配列の場合は、
+                      <String, List<dynamic>>{"items": data} として返却される
+                      ''',
+            );
+          },
+        );
+      },
+    );
+
+    group(
+      'post',
+      () {
+        test('正常系', () {});
+        test(
+          '正常系',
+          () async {
+            const testRequest = <String, dynamic>{
+              'data': <String, dynamic>{
+                'items': <dynamic>[
+                  <String, dynamic>{
+                    'id': 1,
+                    'name': 'test',
+                  },
+                ],
+              },
+            };
+            const testItems = <String, dynamic>{
               'items': <dynamic>[
                 <String, dynamic>{
-                  'id': 1,
+                  'id': 2,
                   'name': 'test',
                 },
               ],
-            },
-          };
-          const testItems = <String, dynamic>{
-            'items': <dynamic>[
-              <String, dynamic>{
-                'id': 2,
-                'name': 'test',
-              },
-            ],
-          };
-          const testResponse = <String, dynamic>{
-            'data': testItems,
-          };
+            };
+            const testResponse = <String, dynamic>{
+              'data': testItems,
+            };
 
+            dioAdapter.onPost(
+              dummyEndpoint,
+              (server) => server.reply(
+                200,
+                testResponse,
+              ),
+              data: testRequest,
+            );
+
+            final response =
+                await container.read(privateTripAppV1ClientProvider).post(
+                      dummyEndpoint,
+                      data: testRequest,
+                    );
+
+            expect(response.data, testItems);
+          },
+        );
+
+        test(
+          '準正常系 ステータスコードが 401 の場合は ApiException が スローされるはず。',
+          () async {
+            dioAdapter.onPost(
+              dummyEndpoint,
+              (server) => server.reply(
+                HttpStatus.unauthorized,
+                <String, dynamic>{
+                  'error_code': 'test',
+                  'description': 'test',
+                },
+              ),
+            );
+            await expectLater(
+              () async {
+                await container.read(privateTripAppV1ClientProvider).post(
+                      dummyEndpoint,
+                    );
+              },
+              throwsA(
+                isA<ApiException>()
+                    .having(
+                      (e) => e.statusCode,
+                      'statusCode',
+                      HttpStatus.unauthorized,
+                    )
+                    .having(
+                      (e) => e.errorCode,
+                      'errorCode',
+                      'test',
+                    )
+                    .having(
+                      (e) => e.description,
+                      'description',
+                      'test',
+                    ),
+              ),
+            );
+          },
+        );
+
+        test('準正常系 レスポンスが null の場合は、ApiException が スローされるはず。', () async {
           dioAdapter.onPost(
             dummyEndpoint,
             (server) => server.reply(
-              200,
-              testResponse,
-            ),
-            data: testRequest,
-          );
-
-          final response =
-              await container.read(privateTripAppV1ClientProvider).post(
-                    dummyEndpoint,
-                    data: testRequest,
-                  );
-
-          expect(response.data, testItems);
-        },
-      );
-
-      test(
-        'post 準正常系 ステータスコードが 401 の場合は ApiException が スローされるはず。',
-        () async {
-          dioAdapter.onPost(
-            dummyEndpoint,
-            (server) => server.reply(
-              HttpStatus.unauthorized,
-              <String, dynamic>{
-                'error_code': 'test',
-                'description': 'test',
-              },
+              HttpStatus.internalServerError,
+              null,
             ),
           );
           await expectLater(
@@ -97,50 +179,15 @@ Future<void> main() async {
                   );
             },
             throwsA(
-              isA<ApiException>()
-                  .having(
-                    (e) => e.statusCode,
-                    'statusCode',
-                    HttpStatus.unauthorized,
-                  )
-                  .having(
-                    (e) => e.errorCode,
-                    'errorCode',
-                    'test',
-                  )
-                  .having(
-                    (e) => e.description,
-                    'description',
-                    'test',
-                  ),
+              isA<ApiException>().having(
+                (e) => e.statusCode,
+                'statusCode',
+                HttpStatus.internalServerError,
+              ),
             ),
           );
-        },
-      );
-
-      test('post 準正常系 レスポンスが null の場合は、ApiException が スローされるはず。', () async {
-        dioAdapter.onPost(
-          dummyEndpoint,
-          (server) => server.reply(
-            HttpStatus.internalServerError,
-            null,
-          ),
-        );
-        await expectLater(
-          () async {
-            await container.read(privateTripAppV1ClientProvider).post(
-                  dummyEndpoint,
-                );
-          },
-          throwsA(
-            isA<ApiException>().having(
-              (e) => e.statusCode,
-              'statusCode',
-              HttpStatus.internalServerError,
-            ),
-          ),
-        );
-      });
-    },
-  );
+        });
+      },
+    );
+  });
 }

--- a/test/feature/trips/data/repositories/trip_repository_test.dart
+++ b/test/feature/trips/data/repositories/trip_repository_test.dart
@@ -49,6 +49,7 @@ Future<void> main() async {
       title: validTitle,
       fromDate: validFromDate,
       endDate: validEndDate,
+      members: [],
     );
     test('正常系', () async {
       when(
@@ -236,6 +237,7 @@ Future<void> main() async {
         title: validTripName,
         fromDate: validFromDate,
         endDate: validEndDate,
+        members: [],
       ),
       status: TripInvitationStatus.open,
       expiredAt: validExpiredDate,

--- a/test/feature/trips/data/repositories/trip_repository_test.dart
+++ b/test/feature/trips/data/repositories/trip_repository_test.dart
@@ -9,7 +9,9 @@ import 'package:trip_app_nativeapp/core/http/response/api_response/api_response.
 import 'package:trip_app_nativeapp/features/trips/data/repositories/trip_repository.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_invitation.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_member.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_invitation_num.dart';
+import 'package:trip_app_nativeapp/features/user/domain/entity/app_user.dart';
 
 import 'trip_repository_test.mocks.dart';
 
@@ -142,4 +144,75 @@ Future<void> main() async {
       );
     });
   });
+
+  group(
+    'fetchTripsByUserId',
+    () {
+      const validUserId = 1;
+      const validName = 'Bob';
+      const validEmail = 'bob@somedomain.com';
+      const validMember = TripMember.joined(
+        isHost: true,
+        user: AppUser(id: validUserId, name: validName, email: validEmail),
+      );
+      final validResult = [
+        Trip.createExistingTrip(
+          title: validTitle,
+          fromDate: validFromDate,
+          endDate: validEndDate,
+          members: [validMember],
+        ),
+      ];
+
+      test('正常系', () async {
+        when(
+          mockApiClient.get(
+            '/users/$validUserId/trips',
+          ),
+        ).thenAnswer((_) async {
+          return ApiResponse(
+            data: {
+              'items': [
+                {
+                  'id': 1,
+                  'name': validTitle,
+                  'members': [
+                    {
+                      'member': {
+                        'id': validUserId,
+                        'name': validName,
+                        'email': validEmail,
+                      },
+                      'is_host': true,
+                    },
+                  ],
+                  'from_date': validFromDate.toJsonDateString(),
+                  'end_date': validEndDate.toJsonDateString(),
+                },
+              ]
+            },
+          );
+        });
+
+        final result = await providerContainer
+            .read(tripRepositoryProvider)
+            .fetchTripsByUserId(validUserId);
+        expect(result, validResult);
+      });
+      test('準正常系 旅取得APIへのリクエスト時の例外はそのままリスローされるはず', () async {
+        when(
+          mockApiClient.get(
+            '/users/$validUserId/trips',
+          ),
+        ).thenThrow(unexpectedException);
+
+        await expectLater(
+          providerContainer
+              .read(tripRepositoryProvider)
+              .fetchTripsByUserId(validUserId),
+          throwsA(isA<Exception>()),
+        );
+      });
+    },
+  );
 }


### PR DESCRIPTION
## 概要
旅のしおり一覧取得機能に必要なリポジトリ層の処理を追加

## 変更点
- `TripRepository` に `fetchTripsByUserId` メソッドを定義
- `fetchTripsByUserId` メソッドに必要なレスポンスモデルを定義
- `Trip` エンティティに members フィールドを追加
- `fetchTripsByUserId` メソッドのテストを追加
