### PR TITLE
Tripエンティティのリファクタリング

### DIFF
--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -15,7 +15,7 @@ const emptyTripTitleMessage = '旅のタイトルを入力してください。'
 const tripDateCompareErrorMessage = '帰宅日は出発日以降に設定してください。';
 
 @riverpod
-Future<List<Trip>> trips(TripsRef ref) => ref
+Future<List<ExistingTrip>> trips(TripsRef ref) => ref
     .watch(tripControllerProvider)
     .fetchTripsByUserId(ref.watch(appUserControllerProvider).value!.id);
 
@@ -46,7 +46,7 @@ class TripController {
     }
   }
 
-  Future<List<Trip>> fetchTripsByUserId(int userId) {
+  Future<List<ExistingTrip>> fetchTripsByUserId(int userId) {
     try {
       return _ref.read(tripInteractorProvider).fetchTripsByUserId(userId);
     } on Exception catch (e) {

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,11 +8,11 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tripsHash() => r'0a9d9323cdd4187af222e1599618e05bd9e89e1e';
+String _$tripsHash() => r'847da4f84e77c3cc4324e388e4e85cdee38eab89';
 
 /// See also [trips].
 @ProviderFor(trips)
-final tripsProvider = AutoDisposeFutureProvider<List<Trip>>.internal(
+final tripsProvider = AutoDisposeFutureProvider<List<ExistingTrip>>.internal(
   trips,
   name: r'tripsProvider',
   debugGetCreateSourceHash:
@@ -21,7 +21,7 @@ final tripsProvider = AutoDisposeFutureProvider<List<Trip>>.internal(
   allTransitiveDependencies: null,
 );
 
-typedef TripsRef = AutoDisposeFutureProviderRef<List<Trip>>;
+typedef TripsRef = AutoDisposeFutureProviderRef<List<ExistingTrip>>;
 String _$tripControllerHash() => r'ecb9d08395accfaf9687b15c2b145bb9a666d1d1';
 
 /// See also [tripController].

--- a/lib/features/trips/data/models/create_trip_response.dart
+++ b/lib/features/trips/data/models/create_trip_response.dart
@@ -7,9 +7,10 @@ part 'create_trip_response.g.dart';
 @freezed
 class CreateTripResponse with _$CreateTripResponse {
   const factory CreateTripResponse({
+    required int id,
     required String name,
-    @DateConverter() required DateTime  fromDate,
-    @DateConverter() required DateTime  endDate, 
+    @DateConverter() required DateTime fromDate,
+    @DateConverter() required DateTime endDate,
   }) = _CreateTripResponse;
 
   factory CreateTripResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/trips/data/models/create_trip_response.freezed.dart
+++ b/lib/features/trips/data/models/create_trip_response.freezed.dart
@@ -20,6 +20,7 @@ CreateTripResponse _$CreateTripResponseFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$CreateTripResponse {
+  int get id => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
   @DateConverter()
   DateTime get fromDate => throw _privateConstructorUsedError;
@@ -39,7 +40,8 @@ abstract class $CreateTripResponseCopyWith<$Res> {
       _$CreateTripResponseCopyWithImpl<$Res, CreateTripResponse>;
   @useResult
   $Res call(
-      {String name,
+      {int id,
+      String name,
       @DateConverter() DateTime fromDate,
       @DateConverter() DateTime endDate});
 }
@@ -57,11 +59,16 @@ class _$CreateTripResponseCopyWithImpl<$Res, $Val extends CreateTripResponse>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? id = null,
     Object? name = null,
     Object? fromDate = null,
     Object? endDate = null,
   }) {
     return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -87,7 +94,8 @@ abstract class _$$_CreateTripResponseCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String name,
+      {int id,
+      String name,
       @DateConverter() DateTime fromDate,
       @DateConverter() DateTime endDate});
 }
@@ -103,11 +111,16 @@ class __$$_CreateTripResponseCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? id = null,
     Object? name = null,
     Object? fromDate = null,
     Object? endDate = null,
   }) {
     return _then(_$_CreateTripResponse(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -128,13 +141,16 @@ class __$$_CreateTripResponseCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_CreateTripResponse implements _CreateTripResponse {
   const _$_CreateTripResponse(
-      {required this.name,
+      {required this.id,
+      required this.name,
       @DateConverter() required this.fromDate,
       @DateConverter() required this.endDate});
 
   factory _$_CreateTripResponse.fromJson(Map<String, dynamic> json) =>
       _$$_CreateTripResponseFromJson(json);
 
+  @override
+  final int id;
   @override
   final String name;
   @override
@@ -146,7 +162,7 @@ class _$_CreateTripResponse implements _CreateTripResponse {
 
   @override
   String toString() {
-    return 'CreateTripResponse(name: $name, fromDate: $fromDate, endDate: $endDate)';
+    return 'CreateTripResponse(id: $id, name: $name, fromDate: $fromDate, endDate: $endDate)';
   }
 
   @override
@@ -154,6 +170,7 @@ class _$_CreateTripResponse implements _CreateTripResponse {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_CreateTripResponse &&
+            (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.fromDate, fromDate) ||
                 other.fromDate == fromDate) &&
@@ -162,7 +179,7 @@ class _$_CreateTripResponse implements _CreateTripResponse {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, name, fromDate, endDate);
+  int get hashCode => Object.hash(runtimeType, id, name, fromDate, endDate);
 
   @JsonKey(ignore: true)
   @override
@@ -181,7 +198,8 @@ class _$_CreateTripResponse implements _CreateTripResponse {
 
 abstract class _CreateTripResponse implements CreateTripResponse {
   const factory _CreateTripResponse(
-          {required final String name,
+          {required final int id,
+          required final String name,
           @DateConverter() required final DateTime fromDate,
           @DateConverter() required final DateTime endDate}) =
       _$_CreateTripResponse;
@@ -189,6 +207,8 @@ abstract class _CreateTripResponse implements CreateTripResponse {
   factory _CreateTripResponse.fromJson(Map<String, dynamic> json) =
       _$_CreateTripResponse.fromJson;
 
+  @override
+  int get id;
   @override
   String get name;
   @override

--- a/lib/features/trips/data/models/create_trip_response.g.dart
+++ b/lib/features/trips/data/models/create_trip_response.g.dart
@@ -15,6 +15,7 @@ _$_CreateTripResponse _$$_CreateTripResponseFromJson(
       json,
       ($checkedConvert) {
         final val = _$_CreateTripResponse(
+          id: $checkedConvert('id', (v) => v as int),
           name: $checkedConvert('name', (v) => v as String),
           fromDate: $checkedConvert(
               'from_date', (v) => const DateConverter().fromJson(v as String)),
@@ -29,6 +30,7 @@ _$_CreateTripResponse _$$_CreateTripResponseFromJson(
 Map<String, dynamic> _$$_CreateTripResponseToJson(
         _$_CreateTripResponse instance) =>
     <String, dynamic>{
+      'id': instance.id,
       'name': instance.name,
       'from_date': const DateConverter().toJson(instance.fromDate),
       'end_date': const DateConverter().toJson(instance.endDate),

--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -63,6 +63,8 @@ class TripRepository implements TripRepositoryInterface {
                   ),
                 )
                 .toList(),
+            // TODO(seigi0714): fetchの際持ち物を追加
+            belongings: [],
           ) as ExistingTrip,
         )
         .toList();
@@ -87,6 +89,7 @@ class TripRepository implements TripRepositoryInterface {
       members: [
         // post のレスポンスにメンバー情報は含まれないので一旦空配列を入れておく
       ],
+      belongings: [], // post のレスポンスにメンバー情報は含まれないので一旦空配列を入れておく
     ) as ExistingTrip;
   }
 
@@ -133,6 +136,7 @@ class TripRepository implements TripRepositoryInterface {
         members: [
           // 招待レスポンスにメンバー情報は含まれないので一旦空配列を入れておく
         ],
+        belongings: [], // 招待レスポンスに持ち物は含まれないので一旦空配列を入れておく
       ),
       invitationUserName: invitationRes.invitationUser.name,
       invitationNum: invitationNum,

--- a/lib/features/trips/domain/entity/trip/trip.dart
+++ b/lib/features/trips/domain/entity/trip/trip.dart
@@ -7,44 +7,18 @@ part 'trip.freezed.dart';
 
 @Freezed(copyWith: false, fromJson: false, toJson: false)
 class Trip with _$Trip {
-  const factory Trip({
-    required TripTitle title,
-    required TripPeriod tripPeriod,
-
-    /// 新規作成時はメンバーがいないので null 許容
-    List<TripMember>? members,
-  }) = _Trip;
-
   /// 新規作成時のfactory関数
   factory Trip.createNewTrip({
-    required String title,
-    required DateTime fromDate,
-    required DateTime endDate,
-  }) {
-    return Trip(
-      title: TripTitle(value: title),
-      tripPeriod: TripPeriod(
-        fromDate: fromDate,
-        endDate: endDate,
-      ),
-    );
-  }
+    required TripTitle title,
+    required TripPeriod period,
+  }) = NewTrip;
 
   /// 作成済み旅エンティティのfactory関数
   /// 現状一緒だけどcreateNewTripと内容変わるはずなので定義しておく
   factory Trip.createExistingTrip({
-    required String title,
-    required DateTime fromDate,
-    required DateTime endDate,
+    required int id,
+    required TripTitle title,
+    required TripPeriod period,
     required List<TripMember> members,
-  }) {
-    return Trip(
-      title: TripTitle(value: title),
-      tripPeriod: TripPeriod(
-        fromDate: fromDate,
-        endDate: endDate,
-      ),
-      members: members,
-    );
-  }
+  }) = ExistingTrip;
 }

--- a/lib/features/trips/domain/entity/trip/trip.dart
+++ b/lib/features/trips/domain/entity/trip/trip.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_belonging.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_member.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_period.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_title.dart';
@@ -20,5 +21,6 @@ class Trip with _$Trip {
     required TripTitle title,
     required TripPeriod period,
     required List<TripMember> members,
+    required List<AddedTripBelonging> belongings,
   }) = ExistingTrip;
 }

--- a/lib/features/trips/domain/entity/trip/trip.freezed.dart
+++ b/lib/features/trips/domain/entity/trip/trip.freezed.dart
@@ -17,72 +17,284 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$Trip {
   TripTitle get title => throw _privateConstructorUsedError;
-  TripPeriod get tripPeriod => throw _privateConstructorUsedError;
-
-  /// 新規作成時はメンバーがいないので null 許容
-  List<TripMember>? get members => throw _privateConstructorUsedError;
+  TripPeriod get period => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(TripTitle title, TripPeriod period) createNewTrip,
+    required TResult Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)
+        createExistingTrip,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(TripTitle title, TripPeriod period)? createNewTrip,
+    TResult? Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)?
+        createExistingTrip,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(TripTitle title, TripPeriod period)? createNewTrip,
+    TResult Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)?
+        createExistingTrip,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NewTrip value) createNewTrip,
+    required TResult Function(ExistingTrip value) createExistingTrip,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NewTrip value)? createNewTrip,
+    TResult? Function(ExistingTrip value)? createExistingTrip,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NewTrip value)? createNewTrip,
+    TResult Function(ExistingTrip value)? createExistingTrip,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 
-class _$_Trip implements _Trip {
-  const _$_Trip(
-      {required this.title,
-      required this.tripPeriod,
-      final List<TripMember>? members})
-      : _members = members;
+class _$NewTrip implements NewTrip {
+  _$NewTrip({required this.title, required this.period});
 
   @override
   final TripTitle title;
   @override
-  final TripPeriod tripPeriod;
-
-  /// 新規作成時はメンバーがいないので null 許容
-  final List<TripMember>? _members;
-
-  /// 新規作成時はメンバーがいないので null 許容
-  @override
-  List<TripMember>? get members {
-    final value = _members;
-    if (value == null) return null;
-    if (_members is EqualUnmodifiableListView) return _members;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+  final TripPeriod period;
 
   @override
   String toString() {
-    return 'Trip(title: $title, tripPeriod: $tripPeriod, members: $members)';
+    return 'Trip.createNewTrip(title: $title, period: $period)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Trip &&
+            other is _$NewTrip &&
             (identical(other.title, title) || other.title == title) &&
-            (identical(other.tripPeriod, tripPeriod) ||
-                other.tripPeriod == tripPeriod) &&
-            const DeepCollectionEquality().equals(other._members, _members));
+            (identical(other.period, period) || other.period == period));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, title, tripPeriod,
-      const DeepCollectionEquality().hash(_members));
+  int get hashCode => Object.hash(runtimeType, title, period);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(TripTitle title, TripPeriod period) createNewTrip,
+    required TResult Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)
+        createExistingTrip,
+  }) {
+    return createNewTrip(title, period);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(TripTitle title, TripPeriod period)? createNewTrip,
+    TResult? Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)?
+        createExistingTrip,
+  }) {
+    return createNewTrip?.call(title, period);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(TripTitle title, TripPeriod period)? createNewTrip,
+    TResult Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)?
+        createExistingTrip,
+    required TResult orElse(),
+  }) {
+    if (createNewTrip != null) {
+      return createNewTrip(title, period);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NewTrip value) createNewTrip,
+    required TResult Function(ExistingTrip value) createExistingTrip,
+  }) {
+    return createNewTrip(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NewTrip value)? createNewTrip,
+    TResult? Function(ExistingTrip value)? createExistingTrip,
+  }) {
+    return createNewTrip?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NewTrip value)? createNewTrip,
+    TResult Function(ExistingTrip value)? createExistingTrip,
+    required TResult orElse(),
+  }) {
+    if (createNewTrip != null) {
+      return createNewTrip(this);
+    }
+    return orElse();
+  }
 }
 
-abstract class _Trip implements Trip {
-  const factory _Trip(
+abstract class NewTrip implements Trip {
+  factory NewTrip(
       {required final TripTitle title,
-      required final TripPeriod tripPeriod,
-      final List<TripMember>? members}) = _$_Trip;
+      required final TripPeriod period}) = _$NewTrip;
 
   @override
   TripTitle get title;
   @override
-  TripPeriod get tripPeriod;
-  @override
+  TripPeriod get period;
+}
 
-  /// 新規作成時はメンバーがいないので null 許容
-  List<TripMember>? get members;
+/// @nodoc
+
+class _$ExistingTrip implements ExistingTrip {
+  _$ExistingTrip(
+      {required this.id,
+      required this.title,
+      required this.period,
+      required final List<TripMember> members})
+      : _members = members;
+
+  @override
+  final int id;
+  @override
+  final TripTitle title;
+  @override
+  final TripPeriod period;
+  final List<TripMember> _members;
+  @override
+  List<TripMember> get members {
+    if (_members is EqualUnmodifiableListView) return _members;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_members);
+  }
+
+  @override
+  String toString() {
+    return 'Trip.createExistingTrip(id: $id, title: $title, period: $period, members: $members)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ExistingTrip &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.period, period) || other.period == period) &&
+            const DeepCollectionEquality().equals(other._members, _members));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, title, period,
+      const DeepCollectionEquality().hash(_members));
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(TripTitle title, TripPeriod period) createNewTrip,
+    required TResult Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)
+        createExistingTrip,
+  }) {
+    return createExistingTrip(id, title, period, members);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(TripTitle title, TripPeriod period)? createNewTrip,
+    TResult? Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)?
+        createExistingTrip,
+  }) {
+    return createExistingTrip?.call(id, title, period, members);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(TripTitle title, TripPeriod period)? createNewTrip,
+    TResult Function(int id, TripTitle title, TripPeriod period,
+            List<TripMember> members)?
+        createExistingTrip,
+    required TResult orElse(),
+  }) {
+    if (createExistingTrip != null) {
+      return createExistingTrip(id, title, period, members);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NewTrip value) createNewTrip,
+    required TResult Function(ExistingTrip value) createExistingTrip,
+  }) {
+    return createExistingTrip(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NewTrip value)? createNewTrip,
+    TResult? Function(ExistingTrip value)? createExistingTrip,
+  }) {
+    return createExistingTrip?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NewTrip value)? createNewTrip,
+    TResult Function(ExistingTrip value)? createExistingTrip,
+    required TResult orElse(),
+  }) {
+    if (createExistingTrip != null) {
+      return createExistingTrip(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ExistingTrip implements Trip {
+  factory ExistingTrip(
+      {required final int id,
+      required final TripTitle title,
+      required final TripPeriod period,
+      required final List<TripMember> members}) = _$ExistingTrip;
+
+  int get id;
+  @override
+  TripTitle get title;
+  @override
+  TripPeriod get period;
+  List<TripMember> get members;
 }

--- a/lib/features/trips/domain/entity/trip/trip.freezed.dart
+++ b/lib/features/trips/domain/entity/trip/trip.freezed.dart
@@ -22,7 +22,7 @@ mixin _$Trip {
   TResult when<TResult extends Object?>({
     required TResult Function(TripTitle title, TripPeriod period) createNewTrip,
     required TResult Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)
+            List<TripMember> members, List<AddedTripBelonging> belongings)
         createExistingTrip,
   }) =>
       throw _privateConstructorUsedError;
@@ -30,7 +30,7 @@ mixin _$Trip {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(TripTitle title, TripPeriod period)? createNewTrip,
     TResult? Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)?
+            List<TripMember> members, List<AddedTripBelonging> belongings)?
         createExistingTrip,
   }) =>
       throw _privateConstructorUsedError;
@@ -38,7 +38,7 @@ mixin _$Trip {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(TripTitle title, TripPeriod period)? createNewTrip,
     TResult Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)?
+            List<TripMember> members, List<AddedTripBelonging> belongings)?
         createExistingTrip,
     required TResult orElse(),
   }) =>
@@ -96,7 +96,7 @@ class _$NewTrip implements NewTrip {
   TResult when<TResult extends Object?>({
     required TResult Function(TripTitle title, TripPeriod period) createNewTrip,
     required TResult Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)
+            List<TripMember> members, List<AddedTripBelonging> belongings)
         createExistingTrip,
   }) {
     return createNewTrip(title, period);
@@ -107,7 +107,7 @@ class _$NewTrip implements NewTrip {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(TripTitle title, TripPeriod period)? createNewTrip,
     TResult? Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)?
+            List<TripMember> members, List<AddedTripBelonging> belongings)?
         createExistingTrip,
   }) {
     return createNewTrip?.call(title, period);
@@ -118,7 +118,7 @@ class _$NewTrip implements NewTrip {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(TripTitle title, TripPeriod period)? createNewTrip,
     TResult Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)?
+            List<TripMember> members, List<AddedTripBelonging> belongings)?
         createExistingTrip,
     required TResult orElse(),
   }) {
@@ -178,8 +178,10 @@ class _$ExistingTrip implements ExistingTrip {
       {required this.id,
       required this.title,
       required this.period,
-      required final List<TripMember> members})
-      : _members = members;
+      required final List<TripMember> members,
+      required final List<AddedTripBelonging> belongings})
+      : _members = members,
+        _belongings = belongings;
 
   @override
   final int id;
@@ -195,9 +197,17 @@ class _$ExistingTrip implements ExistingTrip {
     return EqualUnmodifiableListView(_members);
   }
 
+  final List<AddedTripBelonging> _belongings;
+  @override
+  List<AddedTripBelonging> get belongings {
+    if (_belongings is EqualUnmodifiableListView) return _belongings;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_belongings);
+  }
+
   @override
   String toString() {
-    return 'Trip.createExistingTrip(id: $id, title: $title, period: $period, members: $members)';
+    return 'Trip.createExistingTrip(id: $id, title: $title, period: $period, members: $members, belongings: $belongings)';
   }
 
   @override
@@ -208,22 +218,29 @@ class _$ExistingTrip implements ExistingTrip {
             (identical(other.id, id) || other.id == id) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.period, period) || other.period == period) &&
-            const DeepCollectionEquality().equals(other._members, _members));
+            const DeepCollectionEquality().equals(other._members, _members) &&
+            const DeepCollectionEquality()
+                .equals(other._belongings, _belongings));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, id, title, period,
-      const DeepCollectionEquality().hash(_members));
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      title,
+      period,
+      const DeepCollectionEquality().hash(_members),
+      const DeepCollectionEquality().hash(_belongings));
 
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(TripTitle title, TripPeriod period) createNewTrip,
     required TResult Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)
+            List<TripMember> members, List<AddedTripBelonging> belongings)
         createExistingTrip,
   }) {
-    return createExistingTrip(id, title, period, members);
+    return createExistingTrip(id, title, period, members, belongings);
   }
 
   @override
@@ -231,10 +248,10 @@ class _$ExistingTrip implements ExistingTrip {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(TripTitle title, TripPeriod period)? createNewTrip,
     TResult? Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)?
+            List<TripMember> members, List<AddedTripBelonging> belongings)?
         createExistingTrip,
   }) {
-    return createExistingTrip?.call(id, title, period, members);
+    return createExistingTrip?.call(id, title, period, members, belongings);
   }
 
   @override
@@ -242,12 +259,12 @@ class _$ExistingTrip implements ExistingTrip {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(TripTitle title, TripPeriod period)? createNewTrip,
     TResult Function(int id, TripTitle title, TripPeriod period,
-            List<TripMember> members)?
+            List<TripMember> members, List<AddedTripBelonging> belongings)?
         createExistingTrip,
     required TResult orElse(),
   }) {
     if (createExistingTrip != null) {
-      return createExistingTrip(id, title, period, members);
+      return createExistingTrip(id, title, period, members, belongings);
     }
     return orElse();
   }
@@ -289,7 +306,8 @@ abstract class ExistingTrip implements Trip {
       {required final int id,
       required final TripTitle title,
       required final TripPeriod period,
-      required final List<TripMember> members}) = _$ExistingTrip;
+      required final List<TripMember> members,
+      required final List<AddedTripBelonging> belongings}) = _$ExistingTrip;
 
   int get id;
   @override
@@ -297,4 +315,5 @@ abstract class ExistingTrip implements Trip {
   @override
   TripPeriod get period;
   List<TripMember> get members;
+  List<AddedTripBelonging> get belongings;
 }

--- a/lib/features/trips/domain/interactor/trip_interactor.dart
+++ b/lib/features/trips/domain/interactor/trip_interactor.dart
@@ -3,6 +3,8 @@ import 'package:trip_app_nativeapp/features/trips/data/repositories/trip_reposit
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_invitation.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_invitation_num.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_period.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_title.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/repositories/trip_repository_interface.dart';
 
 part 'trip_interactor.g.dart';
@@ -27,10 +29,12 @@ class TripInteractor {
     DateTime endDate,
   ) async {
     final trip = Trip.createNewTrip(
-      title: title,
-      fromDate: fromDate,
-      endDate: endDate,
-    );
+      title: TripTitle(value: title),
+      period: TripPeriod(
+        fromDate: fromDate,
+        endDate: endDate,
+      ),
+    ) as NewTrip;
     await tripRepo.createTrip(trip);
   }
 

--- a/lib/features/trips/domain/interactor/trip_interactor.dart
+++ b/lib/features/trips/domain/interactor/trip_interactor.dart
@@ -52,6 +52,6 @@ class TripInteractor {
     return result;
   }
 
-  Future<List<Trip>> fetchTripsByUserId(int userId) =>
+  Future<List<ExistingTrip>> fetchTripsByUserId(int userId) =>
       tripRepo.fetchTripsByUserId(userId);
 }

--- a/lib/features/trips/domain/repositories/trip_repository_interface.dart
+++ b/lib/features/trips/domain/repositories/trip_repository_interface.dart
@@ -4,11 +4,11 @@ import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_invita
 
 abstract class TripRepositoryInterface {
   /// 旅データ作成
-  Future<Trip> createTrip(Trip trip);
+  Future<ExistingTrip> createTrip(NewTrip trip);
 
   /// 旅データ取得
   /// ユーザーが参加している旅データ一覧を取得する
-  Future<List<Trip>> fetchTripsByUserId(int userId);
+  Future<List<ExistingTrip>> fetchTripsByUserId(int userId);
 
   /// 招待状作成
   Future<GeneratedTripInvitation> invite(

--- a/lib/view/widgets/trips/trip_card.dart
+++ b/lib/view/widgets/trips/trip_card.dart
@@ -37,12 +37,12 @@ class TripCard extends StatelessWidget {
             ),
             const Gap(8),
             Text(
-              '🛫 ${trip.tripPeriod.fromDate.toJsonDateString()}',
+              '🛫 ${trip.period.fromDate.toJsonDateString()}',
               style: context.textTheme.titleMedium,
             ),
             const Gap(8),
             Text(
-              '${trip.tripPeriod.endDate.toJsonDateString()} 🔚',
+              '${trip.period.endDate.toJsonDateString()} 🔚',
               style: context.textTheme.titleMedium,
             ),
           ],

--- a/lib/view/widgets/trips/trip_card.dart
+++ b/lib/view/widgets/trips/trip_card.dart
@@ -9,7 +9,7 @@ import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
 class TripCard extends StatelessWidget {
   const TripCard(this.trip, {super.key});
 
-  final Trip trip;
+  final ExistingTrip trip;
 
   @override
   Widget build(BuildContext context) {

--- a/test/feature/trips/controller/trip_controller_test.mocks.dart
+++ b/test/feature/trips/controller/trip_controller_test.mocks.dart
@@ -110,12 +110,13 @@ class MockTripInteractor extends _i1.Mock implements _i4.TripInteractor {
         )),
       ) as _i5.Future<_i3.GeneratedTripInvitation>);
   @override
-  _i5.Future<List<_i6.Trip>> fetchTripsByUserId(int? userId) =>
+  _i5.Future<List<_i6.ExistingTrip>> fetchTripsByUserId(int? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchTripsByUserId,
           [userId],
         ),
-        returnValue: _i5.Future<List<_i6.Trip>>.value(<_i6.Trip>[]),
-      ) as _i5.Future<List<_i6.Trip>>);
+        returnValue:
+            _i5.Future<List<_i6.ExistingTrip>>.value(<_i6.ExistingTrip>[]),
+      ) as _i5.Future<List<_i6.ExistingTrip>>);
 }

--- a/test/feature/trips/data/repositories/trip_repository_test.dart
+++ b/test/feature/trips/data/repositories/trip_repository_test.dart
@@ -15,6 +15,8 @@ import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_belonging_num.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_invitation_num.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_invitation_status.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_period.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_title.dart';
 import 'package:trip_app_nativeapp/features/user/domain/entity/app_user.dart';
 
 import 'trip_repository_test.mocks.dart';
@@ -43,17 +45,22 @@ Future<void> main() async {
 
   group('createTrip', () {
     final testNewTrip = Trip.createNewTrip(
-      title: validTitle,
-      fromDate: validFromDate,
-      endDate: validEndDate,
-    );
+      title: TripTitle(value: validTitle),
+      period: TripPeriod(
+        fromDate: validFromDate,
+        endDate: validEndDate,
+      ),
+    ) as NewTrip;
 
     final validResult = Trip.createExistingTrip(
-      title: validTitle,
-      fromDate: validFromDate,
-      endDate: validEndDate,
+      id: 0,
+      title: TripTitle(value: validTitle),
+      period: TripPeriod(
+        fromDate: validFromDate,
+        endDate: validEndDate,
+      ),
       members: [],
-    );
+    ) as ExistingTrip;
     test('正常系', () async {
       when(
         mockApiClient.post(
@@ -68,8 +75,8 @@ Future<void> main() async {
         return ApiResponse(
           data: {
             'name': testNewTrip.title.value,
-            'from_date': testNewTrip.tripPeriod.fromDate.toJsonDateString(),
-            'end_date': testNewTrip.tripPeriod.endDate.toJsonDateString(),
+            'from_date': testNewTrip.period.fromDate.toJsonDateString(),
+            'end_date': testNewTrip.period.endDate.toJsonDateString(),
           },
         );
       });
@@ -162,9 +169,12 @@ Future<void> main() async {
       );
       final validResult = [
         Trip.createExistingTrip(
-          title: validTitle,
-          fromDate: validFromDate,
-          endDate: validEndDate,
+          id: 0,
+          title: TripTitle(value: validTitle),
+          period: TripPeriod(
+            fromDate: validFromDate,
+            endDate: validEndDate,
+          ),
           members: [validMember],
         ),
       ];
@@ -237,9 +247,12 @@ Future<void> main() async {
       invitationUserName: validInvitationUserName,
       invitationNum: TripInvitationNum(value: validInvitationNum),
       trip: Trip.createExistingTrip(
-        title: validTripName,
-        fromDate: validFromDate,
-        endDate: validEndDate,
+        id: validTripId,
+        title: TripTitle(value: validTripName),
+        period: TripPeriod(
+          fromDate: validFromDate,
+          endDate: validEndDate,
+        ),
         members: [],
       ),
       status: TripInvitationStatus.open,

--- a/test/feature/trips/data/repositories/trip_repository_test.dart
+++ b/test/feature/trips/data/repositories/trip_repository_test.dart
@@ -60,6 +60,7 @@ Future<void> main() async {
         endDate: validEndDate,
       ),
       members: [],
+      belongings: [],
     ) as ExistingTrip;
     test('正常系', () async {
       when(
@@ -176,6 +177,7 @@ Future<void> main() async {
             endDate: validEndDate,
           ),
           members: [validMember],
+          belongings: [],
         ),
       ];
 
@@ -254,6 +256,7 @@ Future<void> main() async {
           endDate: validEndDate,
         ),
         members: [],
+        belongings: [],
       ),
       status: TripInvitationStatus.open,
       expiredAt: validExpiredDate,

--- a/test/feature/trips/data/repositories/trip_repository_test.dart
+++ b/test/feature/trips/data/repositories/trip_repository_test.dart
@@ -27,6 +27,7 @@ Future<void> main() async {
 
   final mockApiClient = MockAbstractApiClient();
 
+  const validTripId = 999;
   const validTitle = 'test_user';
   final validFromDate = DateTime(2023);
   final validEndDate = DateTime(2023, 1, 2);
@@ -53,7 +54,7 @@ Future<void> main() async {
     ) as NewTrip;
 
     final validResult = Trip.createExistingTrip(
-      id: 0,
+      id: validTripId,
       title: TripTitle(value: validTitle),
       period: TripPeriod(
         fromDate: validFromDate,
@@ -75,6 +76,7 @@ Future<void> main() async {
       ).thenAnswer((_) async {
         return ApiResponse(
           data: {
+            'id': validTripId,
             'name': testNewTrip.title.value,
             'from_date': testNewTrip.period.fromDate.toJsonDateString(),
             'end_date': testNewTrip.period.endDate.toJsonDateString(),
@@ -161,6 +163,7 @@ Future<void> main() async {
   group(
     'fetchTripsByUserId',
     () {
+      const validTripId = 999;
       const validUserId = 1;
       const validName = 'Bob';
       const validEmail = 'bob@somedomain.com';
@@ -170,7 +173,7 @@ Future<void> main() async {
       );
       final validResult = [
         Trip.createExistingTrip(
-          id: 0,
+          id: validTripId,
           title: TripTitle(value: validTitle),
           period: TripPeriod(
             fromDate: validFromDate,
@@ -191,7 +194,7 @@ Future<void> main() async {
             data: {
               'items': [
                 {
-                  'id': 1,
+                  'id': validTripId,
                   'name': validTitle,
                   'members': [
                     {

--- a/test/feature/trips/domain/trip_interactor_test.dart
+++ b/test/feature/trips/domain/trip_interactor_test.dart
@@ -46,6 +46,7 @@ void main() {
                 ),
               ),
             ],
+            belongings: [],
           ) as ExistingTrip
         ]),
       );

--- a/test/feature/trips/domain/trip_interactor_test.dart
+++ b/test/feature/trips/domain/trip_interactor_test.dart
@@ -5,6 +5,8 @@ import 'package:mockito/mockito.dart';
 import 'package:trip_app_nativeapp/features/trips/data/repositories/trip_repository.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_member.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_period.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_title.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/interactor/trip_interactor.dart';
 import 'package:trip_app_nativeapp/features/user/domain/entity/app_user.dart';
 
@@ -28,9 +30,12 @@ void main() {
       when(mockTripRepo.fetchTripsByUserId(1)).thenAnswer(
         (_) => Future.value([
           Trip.createExistingTrip(
-            title: 'title',
-            fromDate: DateTime(2023, 2, 25),
-            endDate: DateTime(2023, 3, 3),
+            id: 1,
+            title: TripTitle(value: 'title'),
+            period: TripPeriod(
+              fromDate: DateTime(2023, 2, 25),
+              endDate: DateTime(2023, 3, 3),
+            ),
             members: [
               const TripMember.joined(
                 isHost: true,
@@ -41,7 +46,7 @@ void main() {
                 ),
               ),
             ],
-          )
+          ) as ExistingTrip
         ]),
       );
       await expectLater(

--- a/test/feature/trips/domain/trip_interactor_test.mocks.dart
+++ b/test/feature/trips/domain/trip_interactor_test.mocks.dart
@@ -39,8 +39,8 @@ class _FakeAbstractApiClient_0 extends _i1.SmartFake
         );
 }
 
-class _FakeTrip_1 extends _i1.SmartFake implements _i3.Trip {
-  _FakeTrip_1(
+class _FakeExistingTrip_1 extends _i1.SmartFake implements _i3.ExistingTrip {
+  _FakeExistingTrip_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -99,28 +99,30 @@ class MockTripRepository extends _i1.Mock implements _i6.TripRepository {
         ),
       ) as _i2.AbstractApiClient);
   @override
-  _i7.Future<List<_i3.Trip>> fetchTripsByUserId(int? userId) =>
+  _i7.Future<List<_i3.ExistingTrip>> fetchTripsByUserId(int? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchTripsByUserId,
           [userId],
         ),
-        returnValue: _i7.Future<List<_i3.Trip>>.value(<_i3.Trip>[]),
-      ) as _i7.Future<List<_i3.Trip>>);
+        returnValue:
+            _i7.Future<List<_i3.ExistingTrip>>.value(<_i3.ExistingTrip>[]),
+      ) as _i7.Future<List<_i3.ExistingTrip>>);
   @override
-  _i7.Future<_i3.Trip> createTrip(_i3.Trip? trip) => (super.noSuchMethod(
+  _i7.Future<_i3.ExistingTrip> createTrip(_i3.NewTrip? trip) =>
+      (super.noSuchMethod(
         Invocation.method(
           #createTrip,
           [trip],
         ),
-        returnValue: _i7.Future<_i3.Trip>.value(_FakeTrip_1(
+        returnValue: _i7.Future<_i3.ExistingTrip>.value(_FakeExistingTrip_1(
           this,
           Invocation.method(
             #createTrip,
             [trip],
           ),
         )),
-      ) as _i7.Future<_i3.Trip>);
+      ) as _i7.Future<_i3.ExistingTrip>);
   @override
   _i7.Future<_i4.GeneratedTripInvitation> invite(
           _i4.NewTripInvitation? invitation) =>


### PR DESCRIPTION
# やったこと
- 新規作成時と、作成済みエンティティの型を分けた。
　- この２つでは使用するフィールドが異なるので型を分けた
- 旅エンティティに持ち物リストフィールドを追加
  - 実際にAPIで取得するところは後続のタスクで行う。
- エンティティを生成しているところを新factory関数のシグネチャに適応
