### PR TITLE
Feature/update trip presentation

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.10.5",
+  "flutterSdkVersion": "3.10.6",
   "flavors": {}
 }

--- a/build.yaml
+++ b/build.yaml
@@ -19,3 +19,8 @@ targets:
             - implicit_dynamic_type
             - implicit_dynamic_method
             - strict_raw_type
+
+global_options:
+  freezed:
+    runs_before:
+      - riverpod_generator

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -140,7 +140,7 @@ SPEC CHECKSUMS:
   path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  shared_preferences_foundation: e2dae3258e06f44cc55f49d42024fd8dd03c590c
+  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
 
 PODFILE CHECKSUM: c6c917686942610e0d396f39145ce923871cfd9a
 

--- a/lib/core/constants/dummy.dart
+++ b/lib/core/constants/dummy.dart
@@ -1,0 +1,4 @@
+const dummyTripImageUrl1 = 'https://picsum.photos/250?image=77';
+const dummyTripImageUrl2 = 'https://picsum.photos/250?image=22';
+const dummyTripImageUrl3 =
+    'https://tsunagutabi.com/wp-content/uploads/2020/04/%E6%97%85%E8%A1%8C%E3%83%96%E3%83%AD%E3%82%B0%E3%81%AB%E3%81%8A%E3%81%99%E3%81%99%E3%82%81%E3%81%AE%E3%83%95%E3%83%AA%E3%83%BC%E7%94%BB%E5%83%8F%EF%BC%86%E7%B4%A0%E6%9D%90%E3%82%B5%E3%82%A4%E3%83%88%E3%81%BE%E3%81%A8%E3%82%81.jpg';

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -16,11 +16,13 @@ const tripDateCompareErrorMessage = '帰宅日は出発日以降に設定して�
 
 @riverpod
 Future<List<ExistingTrip>> trips(TripsRef ref) => ref
-    .watch(tripControllerProvider)
+    .watch(duplicatedTripControllerProvider)
     .fetchTripsByUserId(ref.watch(appUserControllerProvider).value!.id);
 
 @riverpod
-DuplicatedTripController tripController(TripControllerRef ref) =>
+DuplicatedTripController duplicatedTripController(
+  DuplicatedTripControllerRef ref,
+) =>
     DuplicatedTripController(ref);
 
 class DuplicatedTripController {

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -25,6 +25,21 @@ DuplicatedTripController duplicatedTripController(
 ) =>
     DuplicatedTripController(ref);
 
+@riverpod
+class TripController extends _$TripController {
+  @override
+  FutureOr<List<ExistingTrip>> build() {
+    try {
+      return ref
+          .read(tripInteractorProvider)
+          .fetchTripsByUserId(ref.watch(appUserControllerProvider).value!.id);
+    } on Exception catch (e) {
+      ref.read(exceptionHandlerProvider).handleException(e);
+      rethrow;
+    }
+  }
+}
+
 class DuplicatedTripController {
   DuplicatedTripController(this._ref);
   final Ref _ref;

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -68,32 +68,23 @@ class TripsController extends _$TripsController {
     );
     try {
       final tripToUpdate = state.value?.firstWhere((trip) => trip.id == tripId);
-      assert(
-        tripToUpdate != null,
-        '''
-        TripsController の state が保持していない旅を更新しようとしています。        
-        ''',
-      );
       // 以下の例外のメッセージはユーザーに見せるつもりは無いが、
-      // assert だけでは null チェックが効かないので例外を投げている。
+      // assert では null チェックが効かないので例外を投げている。
       if (tripToUpdate == null) {
         throw const AppException(message: '更新しようとしている旅が存在していません🤔');
       }
-
       final updatedTrip = await ref.read(tripInteractorProvider).updateTrip(
             tripId,
             title ?? tripToUpdate.title.value,
             fromDate ?? tripToUpdate.period.fromDate,
             endDate ?? tripToUpdate.period.endDate,
           );
-
       final updatedTrips = state.value?.map((trip) {
         if (trip.id == updatedTrip.id) {
           return updatedTrip;
         }
         return trip;
       }).toList();
-
       state = AsyncData(updatedTrips ?? []);
     } on Exception catch (e) {
       ref.read(exceptionHandlerProvider).handleException(e);

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -20,10 +20,11 @@ Future<List<ExistingTrip>> trips(TripsRef ref) => ref
     .fetchTripsByUserId(ref.watch(appUserControllerProvider).value!.id);
 
 @riverpod
-TripController tripController(TripControllerRef ref) => TripController(ref);
+DuplicatedTripController tripController(TripControllerRef ref) =>
+    DuplicatedTripController(ref);
 
-class TripController {
-  TripController(this._ref);
+class DuplicatedTripController {
+  DuplicatedTripController(this._ref);
   final Ref _ref;
 
   Future<void> createTrip({

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -88,7 +88,6 @@ class TripsController extends _$TripsController {
       state = AsyncData(updatedTrips ?? []);
     } on Exception catch (e) {
       ref.read(exceptionHandlerProvider).handleException(e);
-      rethrow;
     }
   }
 

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -15,18 +15,13 @@ const emptyTripTitleMessage = '旅のタイトルを入力してください。'
 const tripDateCompareErrorMessage = '帰宅日は出発日以降に設定してください。';
 
 @riverpod
-Future<List<ExistingTrip>> trips(TripsRef ref) => ref
-    .watch(duplicatedTripControllerProvider)
-    .fetchTripsByUserId(ref.watch(appUserControllerProvider).value!.id);
-
-@riverpod
 DuplicatedTripController duplicatedTripController(
   DuplicatedTripControllerRef ref,
 ) =>
     DuplicatedTripController(ref);
 
 @riverpod
-class TripController extends _$TripController {
+class TripsController extends _$TripsController {
   @override
   FutureOr<List<ExistingTrip>> build() {
     try {
@@ -61,15 +56,6 @@ class DuplicatedTripController {
       onSuccess?.call();
     } on Exception catch (e) {
       _ref.read(exceptionHandlerProvider).handleException(e);
-    }
-  }
-
-  Future<List<ExistingTrip>> fetchTripsByUserId(int userId) {
-    try {
-      return _ref.read(tripInteractorProvider).fetchTripsByUserId(userId);
-    } on Exception catch (e) {
-      _ref.read(exceptionHandlerProvider).handleException(e);
-      rethrow;
     }
   }
 

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -68,10 +68,6 @@ class TripsController extends _$TripsController {
       }).toList();
 
       state = AsyncData(updatedTrips ?? []);
-
-      ref
-          .read(scaffoldMessengerHelperProvider)
-          .showSnackBar(createTripSuccessMessage);
     } on Exception catch (e) {
       ref.read(exceptionHandlerProvider).handleException(e);
     }

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/services.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:trip_app_nativeapp/core/exception/exception_handler.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
@@ -15,12 +14,6 @@ const emptyTripTitleMessage = '旅のタイトルを入力してください。'
 const tripDateCompareErrorMessage = '帰宅日は出発日以降に設定してください。';
 
 @riverpod
-DuplicatedTripController duplicatedTripController(
-  DuplicatedTripControllerRef ref,
-) =>
-    DuplicatedTripController(ref);
-
-@riverpod
 class TripsController extends _$TripsController {
   @override
   FutureOr<List<ExistingTrip>> build() {
@@ -33,11 +26,6 @@ class TripsController extends _$TripsController {
       rethrow;
     }
   }
-}
-
-class DuplicatedTripController {
-  DuplicatedTripController(this._ref);
-  final Ref _ref;
 
   Future<void> createTrip({
     required String title,
@@ -46,16 +34,16 @@ class DuplicatedTripController {
     VoidCallback? onSuccess,
   }) async {
     try {
-      await _ref
+      await ref
           .read(tripInteractorProvider)
           .createTrip(title, fromDate, endDate);
 
-      _ref
+      ref
           .read(scaffoldMessengerHelperProvider)
           .showSnackBar(createTripSuccessMessage);
       onSuccess?.call();
     } on Exception catch (e) {
-      _ref.read(exceptionHandlerProvider).handleException(e);
+      ref.read(exceptionHandlerProvider).handleException(e);
     }
   }
 
@@ -65,19 +53,19 @@ class DuplicatedTripController {
   }) async {
     const successMessage = '招待リンクをクリップボードにコピーしました。';
     try {
-      _ref.read(overlayLoadingProvider.notifier).startLoading();
-      final invitation = await _ref
+      ref.read(overlayLoadingProvider.notifier).startLoading();
+      final invitation = await ref
           .read(tripInteractorProvider)
           .invite(tripId: tripId, invitationNum: invitationNum);
 
       // TODO(seigi0714): ダイナミックリンクをクリップボードにコピー
       final data = ClipboardData(text: invitation.invitationCode);
       await Clipboard.setData(data);
-      _ref.read(scaffoldMessengerHelperProvider).showSnackBar(successMessage);
+      ref.read(scaffoldMessengerHelperProvider).showSnackBar(successMessage);
     } on Exception catch (e) {
-      _ref.read(exceptionHandlerProvider).handleException(e);
+      ref.read(exceptionHandlerProvider).handleException(e);
     } finally {
-      _ref.read(overlayLoadingProvider.notifier).endLoading();
+      ref.read(overlayLoadingProvider.notifier).endLoading();
     }
   }
 }

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -49,6 +49,34 @@ class TripsController extends _$TripsController {
     }
   }
 
+  Future<void> updateTrip({
+    required int tripId,
+    required String title,
+    required DateTime fromDate,
+    required DateTime endDate,
+  }) async {
+    try {
+      final updatedTrip = await ref
+          .read(tripInteractorProvider)
+          .updateTrip(tripId, title, fromDate, endDate);
+
+      final updatedTrips = state.value?.map((trip) {
+        if (trip.id == updatedTrip.id) {
+          return updatedTrip;
+        }
+        return trip;
+      }).toList();
+
+      state = AsyncData(updatedTrips ?? []);
+
+      ref
+          .read(scaffoldMessengerHelperProvider)
+          .showSnackBar(createTripSuccessMessage);
+    } on Exception catch (e) {
+      ref.read(exceptionHandlerProvider).handleException(e);
+    }
+  }
+
   Future<void> generateAndCopyInviteLink({
     required int tripId,
     required int invitationNum,

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -50,6 +50,12 @@ class TripsController extends _$TripsController {
     }
   }
 
+  /// [tripId] に一致する旅行情報を更新します。
+  ///
+  /// 更新する情報は、[title]、[fromDate]、[endDate] のいずれかまたは全てです。
+  /// これらのパラメータは null 許容となっており、null の場合は既存の情報が保持されます。
+  ///
+  /// [tripId] 以外の全てのパラメータが null の場合はアサーションエラーになります。
   Future<void> updateTrip({
     required int tripId,
     String? title,
@@ -91,6 +97,7 @@ class TripsController extends _$TripsController {
       state = AsyncData(updatedTrips ?? []);
     } on Exception catch (e) {
       ref.read(exceptionHandlerProvider).handleException(e);
+      rethrow;
     }
   }
 

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -52,7 +52,7 @@ class TripsController extends _$TripsController {
 
   /// [tripId] に一致する旅行情報を更新します。
   ///
-  /// 更新する情報は、[title]、[fromDate]、[endDate] のいずれかまたは全てです。
+  /// 更新できる情報は、[title]、[fromDate]、[endDate] のいずれかまたは全てです。
   /// これらのパラメータは null 許容となっており、null の場合は既存の情報が保持されます。
   ///
   /// [tripId] 以外の全てのパラメータが null の場合はアサーションエラーになります。

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:trip_app_nativeapp/core/exception/app_exception.dart';
 import 'package:trip_app_nativeapp/core/exception/exception_handler.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/interactor/trip_interactor.dart';
@@ -51,14 +52,34 @@ class TripsController extends _$TripsController {
 
   Future<void> updateTrip({
     required int tripId,
-    required String title,
-    required DateTime fromDate,
-    required DateTime endDate,
+    String? title,
+    DateTime? fromDate,
+    DateTime? endDate,
   }) async {
+    assert(
+      title != null || fromDate != null || endDate != null,
+      'tripId 以外の引数が全て null だと旅情報を更新できません。',
+    );
     try {
-      final updatedTrip = await ref
-          .read(tripInteractorProvider)
-          .updateTrip(tripId, title, fromDate, endDate);
+      final tripToUpdate = state.value?.firstWhere((trip) => trip.id == tripId);
+      assert(
+        tripToUpdate != null,
+        '''
+        TripsController の state が保持していない旅を更新しようとしています。        
+        ''',
+      );
+      // 以下の例外のメッセージはユーザーに見せるつもりは無いが、
+      // assert だけでは null チェックが効かないので例外を投げている。
+      if (tripToUpdate == null) {
+        throw const AppException(message: '更新しようとしている旅が存在していません🤔');
+      }
+
+      final updatedTrip = await ref.read(tripInteractorProvider).updateTrip(
+            tripId,
+            title ?? tripToUpdate.title.value,
+            fromDate ?? tripToUpdate.period.fromDate,
+            endDate ?? tripToUpdate.period.endDate,
+          );
 
       final updatedTrips = state.value?.map((trip) {
         if (trip.id == updatedTrip.id) {

--- a/lib/features/trips/controller/trip_controller.dart
+++ b/lib/features/trips/controller/trip_controller.dart
@@ -34,9 +34,11 @@ class TripsController extends _$TripsController {
     VoidCallback? onSuccess,
   }) async {
     try {
-      await ref
+      final newTrip = await ref
           .read(tripInteractorProvider)
           .createTrip(title, fromDate, endDate);
+
+      state = AsyncData([...state.value ?? [], newTrip]);
 
       ref
           .read(scaffoldMessengerHelperProvider)

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -22,20 +22,22 @@ final tripsProvider = AutoDisposeFutureProvider<List<ExistingTrip>>.internal(
 );
 
 typedef TripsRef = AutoDisposeFutureProviderRef<List<ExistingTrip>>;
-String _$tripControllerHash() => r'ecb9d08395accfaf9687b15c2b145bb9a666d1d1';
+String _$duplicatedTripControllerHash() =>
+    r'bde4c961b5d3bd3cbdc004db9c068c940e76747b';
 
-/// See also [tripController].
-@ProviderFor(tripController)
-final tripControllerProvider =
+/// See also [duplicatedTripController].
+@ProviderFor(duplicatedTripController)
+final duplicatedTripControllerProvider =
     AutoDisposeProvider<DuplicatedTripController>.internal(
-  tripController,
-  name: r'tripControllerProvider',
+  duplicatedTripController,
+  name: r'duplicatedTripControllerProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$tripControllerHash,
+      : _$duplicatedTripControllerHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-typedef TripControllerRef = AutoDisposeProviderRef<DuplicatedTripController>;
+typedef DuplicatedTripControllerRef
+    = AutoDisposeProviderRef<DuplicatedTripController>;
 // ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,7 +8,7 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tripsControllerHash() => r'08d4ad9ce5c1a8abfa5cbdeb1a22e7f8a12bc363';
+String _$tripsControllerHash() => r'fea6b321ac3abf20e24a8a02208cab5471348df3';
 
 /// See also [TripsController].
 @ProviderFor(TripsController)

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,7 +8,7 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tripsControllerHash() => r'8e0abac9b92207c97b6f06c62f84948d4fcfecc8';
+String _$tripsControllerHash() => r'08d4ad9ce5c1a8abfa5cbdeb1a22e7f8a12bc363';
 
 /// See also [TripsController].
 @ProviderFor(TripsController)

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,7 +8,7 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tripsHash() => r'847da4f84e77c3cc4324e388e4e85cdee38eab89';
+String _$tripsHash() => r'8a3992ca76d126ea745ec9522b5b20895197a568';
 
 /// See also [trips].
 @ProviderFor(trips)
@@ -40,4 +40,20 @@ final duplicatedTripControllerProvider =
 
 typedef DuplicatedTripControllerRef
     = AutoDisposeProviderRef<DuplicatedTripController>;
+String _$tripControllerHash() => r'dbd98791a881a22471a0a43cba12be2d95628aa2';
+
+/// See also [TripController].
+@ProviderFor(TripController)
+final tripControllerProvider = AutoDisposeAsyncNotifierProvider<TripController,
+    List<ExistingTrip>>.internal(
+  TripController.new,
+  name: r'tripControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$tripControllerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$TripController = AutoDisposeAsyncNotifier<List<ExistingTrip>>;
 // ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,7 +8,7 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tripsControllerHash() => r'20da33a19fe1b530860736dbb93557739f9a1a3f';
+String _$tripsControllerHash() => r'8e0abac9b92207c97b6f06c62f84948d4fcfecc8';
 
 /// See also [TripsController].
 @ProviderFor(TripsController)

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -26,7 +26,8 @@ String _$tripControllerHash() => r'ecb9d08395accfaf9687b15c2b145bb9a666d1d1';
 
 /// See also [tripController].
 @ProviderFor(tripController)
-final tripControllerProvider = AutoDisposeProvider<TripController>.internal(
+final tripControllerProvider =
+    AutoDisposeProvider<DuplicatedTripController>.internal(
   tripController,
   name: r'tripControllerProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -36,5 +37,5 @@ final tripControllerProvider = AutoDisposeProvider<TripController>.internal(
   allTransitiveDependencies: null,
 );
 
-typedef TripControllerRef = AutoDisposeProviderRef<TripController>;
+typedef TripControllerRef = AutoDisposeProviderRef<DuplicatedTripController>;
 // ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,7 +8,7 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tripsControllerHash() => r'c6af6876a433e4ef418ed8efb3c9bfbe87233736';
+String _$tripsControllerHash() => r'2bcf7fcfdafa9410823374f98513a453994594d8';
 
 /// See also [TripsController].
 @ProviderFor(TripsController)

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,7 +8,7 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tripsControllerHash() => r'fea6b321ac3abf20e24a8a02208cab5471348df3';
+String _$tripsControllerHash() => r'c6af6876a433e4ef418ed8efb3c9bfbe87233736';
 
 /// See also [TripsController].
 @ProviderFor(TripsController)

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,25 +8,7 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$duplicatedTripControllerHash() =>
-    r'bde4c961b5d3bd3cbdc004db9c068c940e76747b';
-
-/// See also [duplicatedTripController].
-@ProviderFor(duplicatedTripController)
-final duplicatedTripControllerProvider =
-    AutoDisposeProvider<DuplicatedTripController>.internal(
-  duplicatedTripController,
-  name: r'duplicatedTripControllerProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$duplicatedTripControllerHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
-
-typedef DuplicatedTripControllerRef
-    = AutoDisposeProviderRef<DuplicatedTripController>;
-String _$tripsControllerHash() => r'6e552673c44d95ed970f9e61c6b3e2e5c6c02973';
+String _$tripsControllerHash() => r'20da33a19fe1b530860736dbb93557739f9a1a3f';
 
 /// See also [TripsController].
 @ProviderFor(TripsController)

--- a/lib/features/trips/controller/trip_controller.g.dart
+++ b/lib/features/trips/controller/trip_controller.g.dart
@@ -8,20 +8,6 @@ part of 'trip_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tripsHash() => r'8a3992ca76d126ea745ec9522b5b20895197a568';
-
-/// See also [trips].
-@ProviderFor(trips)
-final tripsProvider = AutoDisposeFutureProvider<List<ExistingTrip>>.internal(
-  trips,
-  name: r'tripsProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : _$tripsHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
-
-typedef TripsRef = AutoDisposeFutureProviderRef<List<ExistingTrip>>;
 String _$duplicatedTripControllerHash() =>
     r'bde4c961b5d3bd3cbdc004db9c068c940e76747b';
 
@@ -40,20 +26,20 @@ final duplicatedTripControllerProvider =
 
 typedef DuplicatedTripControllerRef
     = AutoDisposeProviderRef<DuplicatedTripController>;
-String _$tripControllerHash() => r'dbd98791a881a22471a0a43cba12be2d95628aa2';
+String _$tripsControllerHash() => r'6e552673c44d95ed970f9e61c6b3e2e5c6c02973';
 
-/// See also [TripController].
-@ProviderFor(TripController)
-final tripControllerProvider = AutoDisposeAsyncNotifierProvider<TripController,
-    List<ExistingTrip>>.internal(
-  TripController.new,
-  name: r'tripControllerProvider',
+/// See also [TripsController].
+@ProviderFor(TripsController)
+final tripsControllerProvider = AutoDisposeAsyncNotifierProvider<
+    TripsController, List<ExistingTrip>>.internal(
+  TripsController.new,
+  name: r'tripsControllerProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$tripControllerHash,
+      : _$tripsControllerHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-typedef _$TripController = AutoDisposeAsyncNotifier<List<ExistingTrip>>;
+typedef _$TripsController = AutoDisposeAsyncNotifier<List<ExistingTrip>>;
 // ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -90,6 +90,7 @@ class TripRepository implements TripRepositoryInterface {
         fromDate: tripRes.fromDate,
         endDate: tripRes.endDate,
       ),
+      // TODO(shimizu-saffle): post のレスポンスにメンバー情報を含めるように改修次第テストデータを入れる
       members: [
         // post のレスポンスにメンバー情報は含まれないので一旦空配列を入れておく
       ],

--- a/lib/features/trips/domain/entity/trip/value/trip_title.dart
+++ b/lib/features/trips/domain/entity/trip/value/trip_title.dart
@@ -7,11 +7,11 @@ class TripTitle with _$TripTitle {
   factory TripTitle({required String value}) {
     assert(
       value.isNotEmpty,
-      'UIのコードによって、空文字が入力されないように制御してください💡',
+      'UI のコードによって、空文字が入力されないように制御してください',
     );
     assert(
       value.length <= 25,
-      'UIのコードによって、26文字以上の文字列が入力されないように制御してください💡',
+      'UI のコードによって、26文字以上の文字列が入力されないように制御してください',
     );
     return TripTitle._internal(value: value);
   }

--- a/lib/features/trips/domain/entity/trip/value/trip_title.dart
+++ b/lib/features/trips/domain/entity/trip/value/trip_title.dart
@@ -1,6 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:trip_app_nativeapp/core/exception/app_exception.dart';
-import 'package:trip_app_nativeapp/core/exception/exception_code.dart';
 
 part 'trip_title.freezed.dart';
 
@@ -8,16 +6,13 @@ part 'trip_title.freezed.dart';
 class TripTitle with _$TripTitle {
   factory TripTitle({required String value}) {
     assert(
-      value.length <= 25,
-      'Widget のプロパティによる制御で、26文字以上の文字列が入力されないように制限してください💡',
+      value.isNotEmpty,
+      'UIのコードによって、空文字が入力されないように制御してください💡',
     );
-
-    if (value.isEmpty) {
-      throw const AppException(
-        code: ExceptionCode.invalidTripTitle,
-        message: '旅のタイトルが空文字です🫢',
-      );
-    }
+    assert(
+      value.length <= 25,
+      'UIのコードによって、26文字以上の文字列が入力されないように制御してください💡',
+    );
     return TripTitle._internal(value: value);
   }
 

--- a/lib/features/trips/domain/entity/trip/value/trip_title.dart
+++ b/lib/features/trips/domain/entity/trip/value/trip_title.dart
@@ -7,15 +7,15 @@ part 'trip_title.freezed.dart';
 @Freezed(copyWith: false)
 class TripTitle with _$TripTitle {
   factory TripTitle({required String value}) {
+    assert(
+      value.length <= 25,
+      'Widget のプロパティによる制御で、26文字以上の文字列が入力されないように制限してください💡',
+    );
+
     if (value.isEmpty) {
       throw const AppException(
         code: ExceptionCode.invalidTripTitle,
         message: '旅のタイトルが空文字です🫢',
-      );
-    } else if (value.length > 25) {
-      throw AppException(
-        code: ExceptionCode.invalidTripTitle,
-        message: '旅のタイトルは25文字以下にしてください。現在${value.length}文字です🙇‍♂️',
       );
     }
     return TripTitle._internal(value: value);

--- a/lib/features/trips/domain/entity/trip/value/trip_title.dart
+++ b/lib/features/trips/domain/entity/trip/value/trip_title.dart
@@ -10,7 +10,12 @@ class TripTitle with _$TripTitle {
     if (value.isEmpty) {
       throw const AppException(
         code: ExceptionCode.invalidTripTitle,
-        message: '旅のタイトルが空文字です。',
+        message: '旅のタイトルが空文字です🫢',
+      );
+    } else if (value.length > 25) {
+      throw AppException(
+        code: ExceptionCode.invalidTripTitle,
+        message: '旅のタイトルは25文字以下にしてください。現在${value.length}文字です🙇‍♂️',
       );
     }
     return TripTitle._internal(value: value);

--- a/lib/features/trips/domain/interactor/trip_interactor.dart
+++ b/lib/features/trips/domain/interactor/trip_interactor.dart
@@ -26,7 +26,7 @@ class TripInteractor {
 
   final TripRepositoryInterface tripRepo;
 
-  Future<void> createTrip(
+  Future<ExistingTrip> createTrip(
     String title,
     DateTime fromDate,
     DateTime endDate,
@@ -38,7 +38,7 @@ class TripInteractor {
         endDate: endDate,
       ),
     ) as NewTrip;
-    await tripRepo.createTrip(trip);
+    return tripRepo.createTrip(trip);
   }
 
   Future<ExistingTrip> updateTrip(

--- a/lib/features/user/controller/app_user_controller.dart
+++ b/lib/features/user/controller/app_user_controller.dart
@@ -26,7 +26,6 @@ class AppUserController extends _$AppUserController {
       return state.value;
     }
 
-    final appUser = await ref.watch(userInteractorProvider).fetchUser();
-    return appUser;
+    return ref.watch(userInteractorProvider).fetchUser();
   }
 }

--- a/lib/features/user/controller/app_user_controller.g.dart
+++ b/lib/features/user/controller/app_user_controller.g.dart
@@ -8,7 +8,7 @@ part of 'app_user_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$appUserControllerHash() => r'078403fbf5a1101522bbb337b2caa11a9101317b';
+String _$appUserControllerHash() => r'f3b5d43cf06a91842b1786d510a2ff8b4d409d1c';
 
 /// ログイン中は、ユーザー情報をキャッシュする
 /// ログイン中に実行される処理で、[AppUser] の値を使用する場合は、非null表明演算子を使ってnullチェックを省略する

--- a/lib/view/pages/trips/trip_detail_page.dart
+++ b/lib/view/pages/trips/trip_detail_page.dart
@@ -76,7 +76,7 @@ class TripDetailPage extends HookConsumerWidget {
                                 ),
                                 Positioned(
                                   top: backgroundImageHeight -
-                                      TripOverviewCard.height / 2,
+                                      TripOverviewCard.height / 1.5,
                                   child: TripOverviewCard(tripId: id),
                                 ),
                               ],

--- a/lib/view/pages/trips/trip_detail_page.dart
+++ b/lib/view/pages/trips/trip_detail_page.dart
@@ -77,7 +77,7 @@ class TripDetailPage extends HookConsumerWidget {
                                 Positioned(
                                   top: backgroundImageHeight -
                                       TripOverviewCard.height / 2,
-                                  child: TripOverviewCard(trip),
+                                  child: TripOverviewCard(tripId: id),
                                 ),
                               ],
                             ),

--- a/lib/view/pages/trips/trip_detail_page.dart
+++ b/lib/view/pages/trips/trip_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:trip_app_nativeapp/core/constants/dummy.dart';
 import 'package:trip_app_nativeapp/core/exception/app_exception.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 import 'package:trip_app_nativeapp/features/trips/controller/trip_controller.dart';
@@ -66,9 +67,7 @@ class TripDetailPage extends HookConsumerWidget {
                                   child: Container(
                                     decoration: const BoxDecoration(
                                       image: DecorationImage(
-                                        image: NetworkImage(
-                                          'https://tsunagutabi.com/wp-content/uploads/2020/04/%E6%97%85%E8%A1%8C%E3%83%96%E3%83%AD%E3%82%B0%E3%81%AB%E3%81%8A%E3%81%99%E3%81%99%E3%82%81%E3%81%AE%E3%83%95%E3%83%AA%E3%83%BC%E7%94%BB%E5%83%8F%EF%BC%86%E7%B4%A0%E6%9D%90%E3%82%B5%E3%82%A4%E3%83%88%E3%81%BE%E3%81%A8%E3%82%81.jpg',
-                                        ),
+                                        image: NetworkImage(dummyTripImageUrl1),
                                         fit: BoxFit.cover,
                                       ),
                                     ),

--- a/lib/view/pages/trips/trip_detail_page.dart
+++ b/lib/view/pages/trips/trip_detail_page.dart
@@ -27,7 +27,7 @@ class TripDetailPage extends HookConsumerWidget {
     return Scaffold(
       body: SafeArea(
         top: false,
-        child: ref.watch(tripsProvider).when(
+        child: ref.watch(tripsControllerProvider).when(
               data: (trips) {
                 final trip = trips.firstWhereOrNull((trip) => trip.id == id);
                 if (trip == null) {
@@ -52,8 +52,8 @@ class TripDetailPage extends HookConsumerWidget {
                           trip.title.value,
                           style: context.textTheme.titleLarge,
                         ),
-                        expandedHeight: backgroundImageHeight +
-                            TripOverviewCard.height / 2,
+                        expandedHeight:
+                            backgroundImageHeight + TripOverviewCard.height / 2,
                         flexibleSpace: FlexibleSpaceBar(
                           background: SizedBox(
                             height: backgroundImageHeight +

--- a/lib/view/pages/trips/trips_list_page.dart
+++ b/lib/view/pages/trips/trips_list_page.dart
@@ -16,7 +16,7 @@ class TripListPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       body: SafeArea(
-        child: ref.watch(tripsProvider).when(
+        child: ref.watch(tripsControllerProvider).when(
               data: (trips) {
                 return GridView.builder(
                   gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(

--- a/lib/view/ui_utils.dart
+++ b/lib/view/ui_utils.dart
@@ -2,21 +2,37 @@ import 'package:flutter/material.dart' hide DatePickerTheme;
 import 'package:flutter_datetime_picker_plus/flutter_datetime_picker_plus.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 
+/// * [dateTimeNotifier] 選択した日時で呼び出し元の Widget をリビルドするための ValueNotifier。
+/// useState<DateTime>() が渡されることを想定している。
+///
+/// * [isSelectedNotifier] 日時が選択されたか否かのフラグによって、
+/// 呼び出し元の Widget をリビルドするためのValueNotifier。
+/// useState<bool>() が渡されることを想定している。
+///
+/// * [minTime] DatePicker で選択可能な最小の日付。
+///
+/// * [maxTime] DatePicker で選択可能な最大の日付。
 Future<DateTime?> showTripAppDatePicker(
   BuildContext context, {
-  /// DatePicker で選択された日付を通知するための ValueNotifier
-  /// useState<DateTime>() が渡されることを想定。
   required ValueNotifier<DateTime> dateTimeNotifier,
-
-  /// DatePicker で日付が選択されたか否かを通知するための ValueNotifier
-  /// useState<bool>() が渡されることを想定。
-  required ValueNotifier<bool> isSelectedNotifier,
-}) {
-  return DatePicker.showDatePicker(
+  ValueNotifier<bool>? isSelectedNotifier,
+  DateTime? minTime,
+  DateTime? maxTime,
+}) async {
+  // 完了ボタンが押されなくても、変更した日時を返すようにする。
+  DateTime? result;
+  await DatePicker.showDatePicker(
     context,
-    minTime: DateTime.now(),
+    maxTime: maxTime,
+    minTime: minTime,
+    onChanged: (date) {
+      result = date;
+      isSelectedNotifier?.value = true;
+      dateTimeNotifier.value = date;
+    },
     onConfirm: (date) {
-      isSelectedNotifier.value = true;
+      result = date;
+      isSelectedNotifier?.value = true;
       dateTimeNotifier.value = date;
     },
     currentTime: dateTimeNotifier.value,
@@ -32,4 +48,5 @@ Future<DateTime?> showTripAppDatePicker(
       ),
     ),
   );
+  return result;
 }

--- a/lib/view/ui_utils.dart
+++ b/lib/view/ui_utils.dart
@@ -2,40 +2,27 @@ import 'package:flutter/material.dart' hide DatePickerTheme;
 import 'package:flutter_datetime_picker_plus/flutter_datetime_picker_plus.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 
-/// * [dateTimeNotifier] 選択した日時で呼び出し元の Widget をリビルドするための ValueNotifier。
-/// useState<DateTime>() が渡されることを想定している。
-///
-/// * [isSelectedNotifier] 日時が選択されたか否かのフラグによって、
-/// 呼び出し元の Widget をリビルドするためのValueNotifier。
-/// useState<bool>() が渡されることを想定している。
+/// * [currentTime] DatePicker で初期表示する日時。
 ///
 /// * [minTime] DatePicker で選択可能な最小の日付。
 ///
 /// * [maxTime] DatePicker で選択可能な最大の日付。
+///
+/// 完了ボタンが押されなくても [DatePicker] で選択された日時を返す。
 Future<DateTime?> showTripAppDatePicker(
   BuildContext context, {
-  required ValueNotifier<DateTime> dateTimeNotifier,
-  ValueNotifier<bool>? isSelectedNotifier,
+  DateTime? currentTime,
   DateTime? minTime,
   DateTime? maxTime,
 }) async {
-  // 完了ボタンが押されなくても、変更した日時を返すようにする。
   DateTime? result;
   await DatePicker.showDatePicker(
     context,
+    currentTime: currentTime,
     maxTime: maxTime,
     minTime: minTime,
-    onChanged: (date) {
-      result = date;
-      isSelectedNotifier?.value = true;
-      dateTimeNotifier.value = date;
-    },
-    onConfirm: (date) {
-      result = date;
-      isSelectedNotifier?.value = true;
-      dateTimeNotifier.value = date;
-    },
-    currentTime: dateTimeNotifier.value,
+    onChanged: (date) => result = date,
+    onConfirm: (date) => result = date,
     locale: LocaleType.jp,
     theme: DatePickerTheme(
       backgroundColor: context.theme.colorScheme.onPrimary,

--- a/lib/view/widgets/helpers/text_input_helper.dart
+++ b/lib/view/widgets/helpers/text_input_helper.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:trip_app_nativeapp/view/widgets/helpers/scaffold_messenger.dart';
+
+/// 入力の最大長を制限し、入力が最大長を超えた場合に SnackBar を表示する[TextInputFormatter]。
+///
+/// このフォーマッターは、入力を最大長に収まるように切り詰め、
+/// 入力が最大長を超えた場合には SnackBar でメッセージを表示する。
+///
+/// [maxLength] は入力の最大長。
+///
+/// [ref] は [scaffoldMessengerHelperProvider]にアクセスするために使用。
+///
+/// このクラスの使用例は以下の通りです：
+///
+/// ```dart
+/// final myFormatter = MaxLengthInputFormatterWithSnackBar(ref, 25);
+/// final myTextField = TextField(inputFormatters: [myFormatter]);
+/// ```
+class MaxLengthInputFormatterWithSnackBar
+    extends LengthLimitingTextInputFormatter {
+  MaxLengthInputFormatterWithSnackBar(
+    this.ref,
+    super.max,
+  );
+
+  final WidgetRef ref;
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final result = super.formatEditUpdate(oldValue, newValue);
+    if (newValue.text.length > maxLength!) {
+      ref
+          .read(scaffoldMessengerHelperProvider)
+          .showSnackBar('旅のタイトルは25文字以下でお願いします🙏');
+    }
+    return result;
+  }
+}

--- a/lib/view/widgets/trips/create_trip_sheet.dart
+++ b/lib/view/widgets/trips/create_trip_sheet.dart
@@ -203,11 +203,7 @@ class _CreateButton extends ConsumerWidget {
                       title: titleEditingController.text,
                       fromDate: fromDate.value,
                       endDate: endDate.value,
-                      onSuccess: () {
-                        // TODO(shimizu-saffle): invalidate しない
-                        ref.invalidate(tripsControllerProvider);
-                        Navigator.pop(context);
-                      },
+                      onSuccess: () => Navigator.pop(context),
                     );
               },
         child: const Text('作成'),

--- a/lib/view/widgets/trips/create_trip_sheet.dart
+++ b/lib/view/widgets/trips/create_trip_sheet.dart
@@ -199,12 +199,12 @@ class _CreateButton extends ConsumerWidget {
         onPressed: isTitleEmpty.value
             ? null
             : () {
-                ref.read(tripControllerProvider).createTrip(
+                ref.read(duplicatedTripControllerProvider).createTrip(
                       title: titleEditingController.text,
                       fromDate: fromDate.value,
                       endDate: endDate.value,
                       onSuccess: () {
-                        ref.invalidate(tripControllerProvider);
+                        ref.invalidate(duplicatedTripControllerProvider);
                         Navigator.pop(context);
                       },
                     );

--- a/lib/view/widgets/trips/create_trip_sheet.dart
+++ b/lib/view/widgets/trips/create_trip_sheet.dart
@@ -199,12 +199,13 @@ class _CreateButton extends ConsumerWidget {
         onPressed: isTitleEmpty.value
             ? null
             : () {
-                ref.read(duplicatedTripControllerProvider).createTrip(
+                ref.read(tripsControllerProvider.notifier).createTrip(
                       title: titleEditingController.text,
                       fromDate: fromDate.value,
                       endDate: endDate.value,
                       onSuccess: () {
-                        ref.invalidate(duplicatedTripControllerProvider);
+                        // TODO(shimizu-saffle): invalidate しない
+                        ref.invalidate(tripsControllerProvider);
                         Navigator.pop(context);
                       },
                     );

--- a/lib/view/widgets/trips/create_trip_sheet.dart
+++ b/lib/view/widgets/trips/create_trip_sheet.dart
@@ -116,11 +116,13 @@ class _DateRangeRow extends HookWidget {
           Expanded(
             child: InkWell(
               borderRadius: BorderRadius.circular(16),
-              onTap: () => showTripAppDatePicker(
-                context,
-                dateTimeNotifier: fromDate,
-                isSelectedNotifier: isSelectedFrom,
-              ),
+              onTap: () async {
+                final selectedDate = await showTripAppDatePicker(context);
+                if (selectedDate != null) {
+                  fromDate.value = selectedDate;
+                  isSelectedFrom.value = true;
+                }
+              },
               child: Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
@@ -146,11 +148,16 @@ class _DateRangeRow extends HookWidget {
           Expanded(
             child: InkWell(
               borderRadius: BorderRadius.circular(16),
-              onTap: () => showTripAppDatePicker(
-                context,
-                dateTimeNotifier: endDate,
-                isSelectedNotifier: isSelectedEnd,
-              ),
+              onTap: () async {
+                final selectedDate = await showTripAppDatePicker(
+                  context,
+                  minTime: fromDate.value,
+                );
+                if (selectedDate != null) {
+                  endDate.value = selectedDate;
+                  isSelectedEnd.value = true;
+                }
+              },
               child: Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(

--- a/lib/view/widgets/trips/editable_trip_title_text.dart
+++ b/lib/view/widgets/trips/editable_trip_title_text.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 import 'package:trip_app_nativeapp/features/trips/controller/trip_controller.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
+import 'package:trip_app_nativeapp/view/widgets/helpers/scaffold_messenger.dart';
 import 'package:trip_app_nativeapp/view/widgets/helpers/text_input_helper.dart';
 
 class EditableTripTitleText extends HookConsumerWidget {
@@ -18,12 +19,31 @@ class EditableTripTitleText extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isEditing = useState(false);
     final focusNode = useFocusNode();
+    final previousText = useState(trip.title.value);
     final controller = useTextEditingController(text: trip.title.value);
+    void textEditingListener() {
+      if (controller.text.isEmpty) {
+        ref
+            .read(scaffoldMessengerHelperProvider)
+            .showSnackBar('旅のタイトルが空文字です🫢');
+      }
+    }
+
+    useEffect(
+      () {
+        controller.addListener(textEditingListener);
+        return () => controller.removeListener(textEditingListener);
+      },
+      [],
+    );
 
     useEffect(
       () {
         focusNode.addListener(() {
           if (!focusNode.hasFocus) {
+            if (controller.text.isEmpty) {
+              controller.text = previousText.value;
+            }
             ref.read(tripsControllerProvider.notifier).updateTrip(
                   tripId: trip.id,
                   title: controller.text,

--- a/lib/view/widgets/trips/editable_trip_title_text.dart
+++ b/lib/view/widgets/trips/editable_trip_title_text.dart
@@ -2,28 +2,36 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
+import 'package:trip_app_nativeapp/features/trips/controller/trip_controller.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
 
 class EditableTripTitleText extends HookConsumerWidget {
   const EditableTripTitleText({
-    required this.tripTitle,
+    required this.trip,
     super.key,
   });
 
-  final String tripTitle;
+  final ExistingTrip trip;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isEditing = useState(false);
     final focusNode = useFocusNode();
-    final controller = useTextEditingController(text: tripTitle);
+    final controller = useTextEditingController(text: trip.title.value);
 
     useEffect(
       () {
-        focusNode.addListener(
-          () {
-            if (!focusNode.hasFocus) isEditing.value = false;
-          },
-        );
+        focusNode.addListener(() {
+          if (!focusNode.hasFocus) {
+            ref.read(tripsControllerProvider.notifier).updateTrip(
+                  tripId: trip.id,
+                  title: controller.text,
+                  fromDate: trip.period.fromDate,
+                  endDate: trip.period.endDate,
+                );
+            isEditing.value = false;
+          }
+        });
         return focusNode.dispose;
       },
       [],
@@ -34,18 +42,14 @@ class EditableTripTitleText extends HookConsumerWidget {
             controller: controller,
             focusNode: focusNode,
             style: context.textTheme.headlineSmall,
-            onEditingComplete: () {
-              isEditing.value = false;
-              focusNode.unfocus();
-            },
           )
-        : InkWell(
+        : GestureDetector(
             onTap: () {
               isEditing.value = true;
               focusNode.requestFocus();
             },
             child: Text(
-              tripTitle,
+              controller.text,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: context.textTheme.headlineSmall,

--- a/lib/view/widgets/trips/editable_trip_title_text.dart
+++ b/lib/view/widgets/trips/editable_trip_title_text.dart
@@ -42,7 +42,9 @@ class EditableTripTitleText extends HookConsumerWidget {
         ? TextField(
             controller: controller,
             focusNode: focusNode,
-            style: context.textTheme.headlineSmall,
+            style: controller.text.length < 14
+                ? context.textTheme.headlineSmall
+                : context.textTheme.titleMedium,
             // UI に文字数カウンターを表示したくないので、maxLength プロパティを使わない。
             inputFormatters: [
               MaxLengthInputFormatterWithSnackBar(ref, 25),
@@ -57,7 +59,9 @@ class EditableTripTitleText extends HookConsumerWidget {
               controller.text,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: context.textTheme.headlineSmall,
+              style: controller.text.length < 14
+                  ? context.textTheme.headlineSmall
+                  : context.textTheme.titleMedium,
             ),
           );
   }

--- a/lib/view/widgets/trips/editable_trip_title_text.dart
+++ b/lib/view/widgets/trips/editable_trip_title_text.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
+
+class EditableTripTitleText extends HookConsumerWidget {
+  const EditableTripTitleText({
+    required this.tripTitle,
+    super.key,
+  });
+
+  final String tripTitle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isEditing = useState(false);
+    final focusNode = useFocusNode();
+    final controller = useTextEditingController(text: tripTitle);
+
+    useEffect(
+      () {
+        focusNode.addListener(
+          () {
+            if (!focusNode.hasFocus) isEditing.value = false;
+          },
+        );
+        return focusNode.dispose;
+      },
+      [],
+    );
+
+    return isEditing.value
+        ? TextField(
+            controller: controller,
+            focusNode: focusNode,
+            style: context.textTheme.headlineSmall,
+            onEditingComplete: () {
+              isEditing.value = false;
+              focusNode.unfocus();
+            },
+          )
+        : InkWell(
+            onTap: () {
+              isEditing.value = true;
+              focusNode.requestFocus();
+            },
+            child: Text(
+              tripTitle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: context.textTheme.headlineSmall,
+            ),
+          );
+  }
+}

--- a/lib/view/widgets/trips/editable_trip_title_text.dart
+++ b/lib/view/widgets/trips/editable_trip_title_text.dart
@@ -60,8 +60,6 @@ class EditableTripTitleText extends HookConsumerWidget {
           ref.read(tripsControllerProvider.notifier).updateTrip(
                 tripId: trip.id,
                 title: controller.text,
-                fromDate: trip.period.fromDate,
-                endDate: trip.period.endDate,
               );
           previousText.value = controller.text;
           isEditing.value = false;

--- a/lib/view/widgets/trips/editable_trip_title_text.dart
+++ b/lib/view/widgets/trips/editable_trip_title_text.dart
@@ -21,6 +21,7 @@ class EditableTripTitleText extends HookConsumerWidget {
     final focusNode = useFocusNode();
     final previousText = useState(trip.title.value);
     final controller = useTextEditingController(text: trip.title.value);
+
     void textEditingListener() {
       if (controller.text.isEmpty) {
         ref
@@ -31,31 +32,31 @@ class EditableTripTitleText extends HookConsumerWidget {
 
     useEffect(
       () {
+        // useEffect で showSnackBar を出すとアサーションエラーになるため、addListener で処理を登録する。
         controller.addListener(textEditingListener);
         return () => controller.removeListener(textEditingListener);
       },
       [],
     );
 
+    useListenable(focusNode);
     useEffect(
       () {
-        focusNode.addListener(() {
-          if (!focusNode.hasFocus) {
-            if (controller.text.isEmpty) {
-              controller.text = previousText.value;
-            }
-            ref.read(tripsControllerProvider.notifier).updateTrip(
-                  tripId: trip.id,
-                  title: controller.text,
-                  fromDate: trip.period.fromDate,
-                  endDate: trip.period.endDate,
-                );
-            isEditing.value = false;
+        if (!focusNode.hasFocus) {
+          if (controller.text.isEmpty) {
+            controller.text = previousText.value;
           }
-        });
-        return focusNode.dispose;
+          ref.read(tripsControllerProvider.notifier).updateTrip(
+                tripId: trip.id,
+                title: controller.text,
+                fromDate: trip.period.fromDate,
+                endDate: trip.period.endDate,
+              );
+          isEditing.value = false;
+        }
+        return null;
       },
-      [],
+      [focusNode.hasFocus],
     );
 
     return isEditing.value

--- a/lib/view/widgets/trips/editable_trip_title_text.dart
+++ b/lib/view/widgets/trips/editable_trip_title_text.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 import 'package:trip_app_nativeapp/features/trips/controller/trip_controller.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
+import 'package:trip_app_nativeapp/view/widgets/helpers/text_input_helper.dart';
 
 class EditableTripTitleText extends HookConsumerWidget {
   const EditableTripTitleText({
@@ -42,6 +43,10 @@ class EditableTripTitleText extends HookConsumerWidget {
             controller: controller,
             focusNode: focusNode,
             style: context.textTheme.headlineSmall,
+            // UI に文字数カウンターを表示したくないので、maxLength プロパティを使わない。
+            inputFormatters: [
+              MaxLengthInputFormatterWithSnackBar(ref, 25),
+            ],
           )
         : GestureDetector(
             onTap: () {

--- a/lib/view/widgets/trips/trip_overview_card.dart
+++ b/lib/view/widgets/trips/trip_overview_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 import 'package:trip_app_nativeapp/core/extensions/datetime.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
+import 'package:trip_app_nativeapp/view/widgets/trips/editable_trip_title_text.dart';
 
 class TripOverviewCard extends StatelessWidget {
   const TripOverviewCard(this.trip, {super.key});
@@ -31,11 +32,8 @@ class TripOverviewCard extends StatelessWidget {
                 Expanded(
                   child: Container(
                     alignment: Alignment.centerLeft,
-                    child: Text(
-                      trip.title.value,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: context.textTheme.headlineMedium,
+                    child: EditableTripTitleText(
+                      tripTitle: trip.title.value,
                     ),
                   ),
                 ),
@@ -64,16 +62,6 @@ class TripOverviewCard extends StatelessWidget {
                         onPressed: () => log('share'),
                         icon: const Icon(
                           Icons.share,
-                        ),
-                      ),
-                    ),
-                    SizedBox(
-                      width: 36,
-                      height: 36,
-                      child: IconButton(
-                        onPressed: () => log('edit'),
-                        icon: const Icon(
-                          Icons.edit,
                         ),
                       ),
                     ),

--- a/lib/view/widgets/trips/trip_overview_card.dart
+++ b/lib/view/widgets/trips/trip_overview_card.dart
@@ -38,23 +38,17 @@ class TripOverviewCard extends StatelessWidget {
                   ),
                 ),
                 Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            '🛫 ${trip.period.fromDate.toJsonDateString()}',
-                            style: context.textTheme.titleMedium,
-                          ),
-                          Text(
-                            '${trip.period.endDate.toJsonDateString()} 🔚',
-                            style: context.textTheme.titleMedium,
-                          ),
-                        ],
-                      ),
+                    Text(
+                      '🛫 ${trip.period.fromDate.toJsonDateString()}',
+                      style: context.textTheme.titleMedium,
                     ),
+                    const Text(' / '),
+                    Text(
+                      '${trip.period.endDate.toJsonDateString()} 🔚',
+                      style: context.textTheme.titleMedium,
+                    ),
+                    const Spacer(),
                     SizedBox(
                       width: 36,
                       height: 36,

--- a/lib/view/widgets/trips/trip_overview_card.dart
+++ b/lib/view/widgets/trips/trip_overview_card.dart
@@ -82,6 +82,7 @@ class TripOverviewCard extends HookConsumerWidget {
                       onTap: () async {
                         final newEndDate = await showTripAppDatePicker(
                           context,
+                          currentTime: selectedTrip.period.endDate,
                           minTime: selectedTrip.period.fromDate,
                         );
                         if (newEndDate != null) {

--- a/lib/view/widgets/trips/trip_overview_card.dart
+++ b/lib/view/widgets/trips/trip_overview_card.dart
@@ -1,25 +1,36 @@
 import 'dart:developer';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 import 'package:trip_app_nativeapp/core/extensions/datetime.dart';
 import 'package:trip_app_nativeapp/features/trips/controller/trip_controller.dart';
-import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
 import 'package:trip_app_nativeapp/view/ui_utils.dart';
 import 'package:trip_app_nativeapp/view/widgets/trips/editable_trip_title_text.dart';
 
 class TripOverviewCard extends HookConsumerWidget {
-  const TripOverviewCard(this.trip, {super.key});
+  const TripOverviewCard({
+    required this.tripId,
+    super.key,
+  });
 
-  final ExistingTrip trip;
+  final int tripId;
   static const height = 150.0;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final fromDate = useState(trip.period.fromDate);
-    final endDate = useState(trip.period.endDate);
+    final selectedTrip = ref.watch(
+      tripsControllerProvider.select(
+        (tripsAsync) => tripsAsync.asData?.value
+            .firstWhereOrNull((trip) => trip.id == tripId),
+      ),
+    );
+    if (selectedTrip == null) {
+      return const Center(
+        child: Text('選択した旅が見つかりませんでした🙇‍♂️'),
+      );
+    }
     return Center(
       child: SizedBox(
         height: height,
@@ -38,7 +49,7 @@ class TripOverviewCard extends HookConsumerWidget {
                 Expanded(
                   child: Container(
                     alignment: Alignment.centerLeft,
-                    child: EditableTripTitleText(trip: trip),
+                    child: EditableTripTitleText(trip: selectedTrip),
                   ),
                 ),
                 Row(
@@ -48,25 +59,20 @@ class TripOverviewCard extends HookConsumerWidget {
                       onTap: () async {
                         final newFromDate = await showTripAppDatePicker(
                           context,
-                          dateTimeNotifier: fromDate,
-                          maxTime: endDate.value,
+                          currentTime: selectedTrip.period.fromDate,
+                          maxTime: selectedTrip.period.endDate,
                         );
                         if (newFromDate != null) {
-                          try {
-                            await ref
-                                .read(tripsControllerProvider.notifier)
-                                .updateTrip(
-                                  tripId: trip.id,
-                                  fromDate: newFromDate,
-                                );
-                          } catch (_) {
-                            // 更新に失敗した場合は元の日付に戻してリビルドする。
-                            fromDate.value = trip.period.fromDate;
-                          }
+                          await ref
+                              .read(tripsControllerProvider.notifier)
+                              .updateTrip(
+                                tripId: selectedTrip.id,
+                                fromDate: newFromDate,
+                              );
                         }
                       },
                       child: Text(
-                        '🛫 ${fromDate.value.toJsonDateString()}',
+                        '🛫 ${selectedTrip.period.fromDate.toJsonDateString()}',
                         style: context.textTheme.titleMedium,
                       ),
                     ),
@@ -76,25 +82,19 @@ class TripOverviewCard extends HookConsumerWidget {
                       onTap: () async {
                         final newEndDate = await showTripAppDatePicker(
                           context,
-                          dateTimeNotifier: endDate,
-                          minTime: fromDate.value,
+                          minTime: selectedTrip.period.fromDate,
                         );
                         if (newEndDate != null) {
-                          try {
-                            await ref
-                                .read(tripsControllerProvider.notifier)
-                                .updateTrip(
-                                  tripId: trip.id,
-                                  endDate: newEndDate,
-                                );
-                          } catch (_) {
-                            // 更新に失敗した場合は元の日付に戻してリビルドする。
-                            endDate.value = trip.period.endDate;
-                          }
+                          await ref
+                              .read(tripsControllerProvider.notifier)
+                              .updateTrip(
+                                tripId: selectedTrip.id,
+                                endDate: newEndDate,
+                              );
                         }
                       },
                       child: Text(
-                        '${endDate.value.toJsonDateString()} 🔚',
+                        '${selectedTrip.period.endDate.toJsonDateString()} 🔚',
                         style: context.textTheme.titleMedium,
                       ),
                     ),

--- a/lib/view/widgets/trips/trip_overview_card.dart
+++ b/lib/view/widgets/trips/trip_overview_card.dart
@@ -1,19 +1,25 @@
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:trip_app_nativeapp/core/extensions/build_context.dart';
 import 'package:trip_app_nativeapp/core/extensions/datetime.dart';
+import 'package:trip_app_nativeapp/features/trips/controller/trip_controller.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
+import 'package:trip_app_nativeapp/view/ui_utils.dart';
 import 'package:trip_app_nativeapp/view/widgets/trips/editable_trip_title_text.dart';
 
-class TripOverviewCard extends StatelessWidget {
+class TripOverviewCard extends HookConsumerWidget {
   const TripOverviewCard(this.trip, {super.key});
 
   final ExistingTrip trip;
   static const height = 150.0;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final fromDate = useState(trip.period.fromDate);
+    final endDate = useState(trip.period.endDate);
     return Center(
       child: SizedBox(
         height: height,
@@ -37,14 +43,60 @@ class TripOverviewCard extends StatelessWidget {
                 ),
                 Row(
                   children: [
-                    Text(
-                      '🛫 ${trip.period.fromDate.toJsonDateString()}',
-                      style: context.textTheme.titleMedium,
+                    InkWell(
+                      borderRadius: BorderRadius.circular(4),
+                      onTap: () async {
+                        final newFromDate = await showTripAppDatePicker(
+                          context,
+                          dateTimeNotifier: fromDate,
+                          maxTime: endDate.value,
+                        );
+                        if (newFromDate != null) {
+                          try {
+                            await ref
+                                .read(tripsControllerProvider.notifier)
+                                .updateTrip(
+                                  tripId: trip.id,
+                                  fromDate: newFromDate,
+                                );
+                          } catch (_) {
+                            // 更新に失敗した場合は元の日付に戻してリビルドする。
+                            fromDate.value = trip.period.fromDate;
+                          }
+                        }
+                      },
+                      child: Text(
+                        '🛫 ${fromDate.value.toJsonDateString()}',
+                        style: context.textTheme.titleMedium,
+                      ),
                     ),
                     const Text(' / '),
-                    Text(
-                      '${trip.period.endDate.toJsonDateString()} 🔚',
-                      style: context.textTheme.titleMedium,
+                    InkWell(
+                      borderRadius: BorderRadius.circular(4),
+                      onTap: () async {
+                        final newEndDate = await showTripAppDatePicker(
+                          context,
+                          dateTimeNotifier: endDate,
+                          minTime: fromDate.value,
+                        );
+                        if (newEndDate != null) {
+                          try {
+                            await ref
+                                .read(tripsControllerProvider.notifier)
+                                .updateTrip(
+                                  tripId: trip.id,
+                                  endDate: newEndDate,
+                                );
+                          } catch (_) {
+                            // 更新に失敗した場合は元の日付に戻してリビルドする。
+                            endDate.value = trip.period.endDate;
+                          }
+                        }
+                      },
+                      child: Text(
+                        '${endDate.value.toJsonDateString()} 🔚',
+                        style: context.textTheme.titleMedium,
+                      ),
                     ),
                     const Spacer(),
                     SizedBox(

--- a/lib/view/widgets/trips/trip_overview_card.dart
+++ b/lib/view/widgets/trips/trip_overview_card.dart
@@ -32,9 +32,7 @@ class TripOverviewCard extends StatelessWidget {
                 Expanded(
                   child: Container(
                     alignment: Alignment.centerLeft,
-                    child: EditableTripTitleText(
-                      tripTitle: trip.title.value,
-                    ),
+                    child: EditableTripTitleText(trip: trip),
                   ),
                 ),
                 Row(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -537,18 +537,18 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: a9520490532087cf38bf3f7de478ab6ebeb5f68bb1eb2641546d92719b224445
+      sha256: "2df89855fe181baae3b6d714dc3c4317acf4fccd495a6f36e5e00f24144c6c3b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.4.1"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -726,7 +726,7 @@ packages:
     source: hosted
     version: "0.6.7"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "43865b79fbb78532e4bff7c33087aa43b1d488c4fdef014eaef568af6d8016dc"
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   build_config:
     dependency: transitive
     description:
@@ -101,18 +101,18 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
+      sha256: "6c4dd11d05d056e76320b828a1db0fc01ccd376922526f8e9d6c796a5adbac20"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "5e1929ad37d48bd382b124266cb8e521de5548d406a45a5ae6656c13dab73e37"
+      sha256: "10c6bcdbf9d049a0b666702cf1cee4ddfdc38f02a19d35ae392863b47519848b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "2.4.6"
   build_runner_core:
     dependency: transitive
     description:
@@ -277,18 +277,18 @@ packages:
     dependency: transitive
     description:
       name: dart_jsonwebtoken
-      sha256: f565a76800b01d3216296a049bc8f189695ab2433afa36cad0e086e46b48d70d
+      sha256: e878f2ee660aba6536d23aca710a475b2dd1ccf61130e2341fbb07cc98442f4a
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.8.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: f4f1f73ab3fd2afcbcca165ee601fe980d966af6a21b5970c6c9376955c528ad
+      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   dartx:
     dependency: transitive
     description:
@@ -529,10 +529,10 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      sha256: "959ef4add147753f990b4a7c6cccb746d5792dbdc81b1cde99e62e7edb31b206"
+      sha256: "5fb789145cae1f4c3245c58b3f8fb287d055c26323879eab57a7bf0cfd1e45f3"
       url: "https://pub.dev"
     source: hosted
-    version: "10.4.0"
+    version: "10.5.0"
   freezed:
     dependency: "direct dev"
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: e89179df2bbcc5988c0e2e98d1c95d471fe7910d323a15b5569ac6eddf085b95
+      sha256: "8d60a787b29cb7d2bcf29230865f4a91f17323c6ac5b6b9027a6418e48d9ffc3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.15"
+    version: "6.1.18"
   google_sign_in_ios:
     dependency: transitive
     description:
@@ -673,10 +673,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "4c3f04bfb64d3efd508d06b41b825542f08122d30bda4933fb95c069d22a4fa3"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   http_mock_adapter:
     dependency: "direct dev"
     description:
@@ -737,10 +737,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "61a60716544392a82726dd0fa1dd6f5f1fd32aec66422b6e229e7b90d52325c4"
+      sha256: aa1f5a8912615733e0fdc7a02af03308933c93235bdc8d50d0b0c8a8ccb0b969
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.7.1"
   lints:
     dependency: transitive
     description:
@@ -1065,58 +1065,58 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "396f85b8afc6865182610c0a2fc470853d56499f75f7499e2a73a9f0539d23d0"
+      sha256: "0344316c947ffeb3a529eac929e1978fcd37c26be4e8468628bac399365a3ca1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "6478c6bbbecfe9aced34c483171e90d7c078f5883558b30ec3163cf18402c749"
+      sha256: fe8401ec5b6dcd739a0fe9588802069e608c3fdbfd3c3c93e546cf2f90438076
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: e014107bb79d6d3297196f4f2d0db54b5d1f85b8ea8ff63b8e8b391a02700feb
+      sha256: b046999bf0ff58f04c364491bb803dcfa8f42e47b19c75478f53d323684a8cc1
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.3.1"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: "9d387433ca65717bbf1be88f4d5bb18f10508917a8fa2fb02e0fd0d7479a9afa"
+      sha256: "71d6806d1449b0a9d4e85e0c7a917771e672a3d5dc61149cc9fac871115018e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: fb5cf25c0235df2d0640ac1b1174f6466bd311f621574997ac59018a6664548d
+      sha256: "23b052f17a25b90ff2b61aad4cc962154da76fb62848a9ce088efe30d7c50ab1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "74083203a8eae241e0de4a0d597dbedab3b8fef5563f33cf3c12d7e93c655ca5"
+      sha256: "7347b194fb0bbeb4058e6a4e87ee70350b6b2b90f8ac5f8bd5b3a01548f6d33a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: "5e588e2efef56916a3b229c3bfe81e6a525665a454519ca51dbcc4236a274173"
+      sha256: f95e6a43162bce43c9c3405f3eb6f39e5b5d11f65fab19196cf8225e2777624d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   shelf:
     dependency: transitive
     description:
@@ -1158,18 +1158,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "373f96cf5a8744bc9816c1ff41cf5391bbdbe3d7a96fe98c622b6738a8a7bd33"
+      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "3b67aade1d52416149c633ba1bb36df44d97c6b51830c2198e934e3fca87ca1f"
+      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1318,10 +1318,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f3743ca475e0c9ef71df4ba15eb2d7684eecd5c8ba20a462462e4e8b561b2e11
+      sha256: b8c67f5fa3897b122cf60fe9ff314f7b0ef71eab25c5f8b771480bc338f48823
       url: "https://pub.dev"
     source: hosted
-    version: "11.6.0"
+    version: "11.7.2"
   watcher:
     dependency: transitive
     description:
@@ -1350,10 +1350,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "7dacfda1edcca378031db9905ad7d7bd56b29fd1a90b0908b71a52a12c41e36b"
+      sha256: dfdf0136e0aa7a1b474ea133e67cb0154a0acd2599c4f3ada3b49d38d38793ee
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.3"
+    version: "5.0.5"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,13 +28,13 @@ dependencies:
   flutter_spinkit: ^5.2.0
   font_awesome_flutter: ^10.2.1
   freezed_annotation: ^2.2.0
-  json_annotation: ^4.8.1
   gap: ^3.0.1
   go_router: ^5.0.5
   google_fonts: ^5.1.0
   google_sign_in: ^6.1.4
   hooks_riverpod: ^2.3.6
   intl: ^0.18.0
+  json_annotation: ^4.8.1
   lottie: ^2.3.2
   mockito: ^5.4.2
   mocktail: ^0.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   mockito: ^5.4.2
   mocktail: ^0.3.0
   nil: ^1.1.1
-  riverpod_annotation: ^2.0.2
+  riverpod_annotation: ^2.1.1
   roggle: ^0.3.0
   shared_preferences: ^2.1.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   flutter_spinkit: ^5.2.0
   font_awesome_flutter: ^10.2.1
   freezed_annotation: ^2.2.0
+  json_annotation: ^4.8.1
   gap: ^3.0.1
   go_router: ^5.0.5
   google_fonts: ^5.1.0
@@ -43,15 +44,15 @@ dependencies:
   shared_preferences: ^2.1.1
 
 dev_dependencies:
-  build_runner: ^2.4.5
+  build_runner: ^2.4.6
   custom_lint: ^0.4.0
   flutter_lints: ^2.0.2
   flutter_test:
     sdk: flutter
-  freezed: ^2.3.5
+  freezed: ^2.4.1
   google_sign_in_mocks: ^0.3.0
   http_mock_adapter: ^0.3.3
-  json_serializable: ^6.7.0
+  json_serializable: ^6.7.1
   riverpod_generator: ^2.2.3
   riverpod_lint: ^1.3.2
   very_good_analysis: ^4.0.0+1

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -145,6 +145,29 @@ Future<void> main() async {
     });
   });
 
+  test('異常系 例外が生じた際は handleException が呼ばれる', () {
+    when(
+      mockTripInteractor.fetchTripsByUserId(validUserId),
+    ).thenThrow(unexpectedException);
+
+    when(
+      mockExceptionHandler.handleException(
+        unexpectedException,
+      ),
+    ).thenReturn(null);
+
+    expect(
+      () => providerContainer.read(tripsControllerProvider.future),
+      throwsA(unexpectedException),
+    );
+
+    verify(
+      mockExceptionHandler.handleException(
+        unexpectedException,
+      ),
+    ).called(1);
+  });
+
   group('TripsController.createTrip', () {
     const newTripId = 2;
     final newTrip = ExistingTrip(

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -265,5 +265,250 @@ Future<void> main() async {
     });
   });
 
+  group(
+    'TripsController.updateTrip',
+    () {
+      final existingTrip = ExistingTrip(
+        id: validTripId,
+        title: TripTitle(value: validTitleValue),
+        period: TripPeriod(
+          fromDate: validFromDate,
+          endDate: validEndDate,
+        ),
+        members: [validMember],
+        belongings: [],
+      );
+      const updateTripTitleValue = '更新後の旅のタイトル';
+      final updateFromDate = validFromDate.add(const Duration(days: 1));
+      final updateEndDate = validEndDate.add(const Duration(days: 1));
+      final updatedAllTrip = ExistingTrip(
+        id: validTripId,
+        title: TripTitle(value: updateTripTitleValue),
+        period: TripPeriod(
+          fromDate: updateFromDate,
+          endDate: updateEndDate,
+        ),
+        members: [validMember],
+        belongings: [],
+      );
+
+      final updatedTitleOnlyTrip = ExistingTrip(
+        id: validTripId,
+        title: TripTitle(value: updateTripTitleValue),
+        period: TripPeriod(
+          fromDate: validFromDate,
+          endDate: validEndDate,
+        ),
+        members: [validMember],
+        belongings: [],
+      );
+
+      final updatedFromDateOnlyTrip = ExistingTrip(
+        id: validTripId,
+        title: TripTitle(value: validTitleValue),
+        period: TripPeriod(
+          fromDate: updateFromDate,
+          endDate: validEndDate,
+        ),
+        members: [validMember],
+        belongings: [],
+      );
+
+      final updatedEndDateOnlyTrip = ExistingTrip(
+        id: validTripId,
+        title: TripTitle(value: validTitleValue),
+        period: TripPeriod(
+          fromDate: validFromDate,
+          endDate: updateEndDate,
+        ),
+        members: [validMember],
+        belongings: [],
+      );
+
+      test(
+        '正常系 タイトル・出発日・帰着日を一度に更新できる',
+        () async {
+          when(
+            mockTripInteractor.fetchTripsByUserId(validUserId),
+          ).thenAnswer(
+            (_) => Future.value([existingTrip]),
+          );
+          when(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              updateTripTitleValue,
+              updateFromDate,
+              updateEndDate,
+            ),
+          ).thenAnswer((_) => Future.value(updatedAllTrip));
+
+          // TripsController の state に trip をセット
+          await providerContainer.read(tripsControllerProvider.future);
+          await expectLater(
+            providerContainer.read(tripsControllerProvider.notifier).updateTrip(
+                  tripId: validTripId,
+                  title: updateTripTitleValue,
+                  fromDate: updateFromDate,
+                  endDate: updateEndDate,
+                ),
+            completes,
+          );
+          verify(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              updateTripTitleValue,
+              updateFromDate,
+              updateEndDate,
+            ),
+          ).called(1);
+          verifyNever(
+            mockExceptionHandler.handleException(
+              unexpectedException,
+            ),
+          );
+          expect(
+            providerContainer.read(tripsControllerProvider).asData?.value,
+            [updatedAllTrip],
+          );
+        },
+      );
+
+      test(
+        '正常系 タイトルだけを更新できる',
+        () async {
+          when(
+            mockTripInteractor.fetchTripsByUserId(validUserId),
+          ).thenAnswer(
+            (_) => Future.value([existingTrip]),
+          );
+          when(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              updateTripTitleValue,
+              validFromDate,
+              validEndDate,
+            ),
+          ).thenAnswer((_) => Future.value(updatedTitleOnlyTrip));
+
+          await providerContainer.read(tripsControllerProvider.future);
+          await expectLater(
+            providerContainer.read(tripsControllerProvider.notifier).updateTrip(
+                  tripId: validTripId,
+                  title: updateTripTitleValue,
+                ),
+            completes,
+          );
+          expect(
+            providerContainer.read(tripsControllerProvider).asData?.value,
+            [updatedTitleOnlyTrip],
+          );
+          verify(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              updateTripTitleValue,
+              validFromDate,
+              validEndDate,
+            ),
+          ).called(1);
+          verifyNever(
+            mockExceptionHandler.handleException(
+              unexpectedException,
+            ),
+          );
+        },
+      );
+
+      test(
+        '正常系 出発日だけを更新できる',
+        () async {
+          when(
+            mockTripInteractor.fetchTripsByUserId(validUserId),
+          ).thenAnswer(
+            (_) => Future.value([existingTrip]),
+          );
+          when(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              validTitleValue,
+              updateFromDate,
+              validEndDate,
+            ),
+          ).thenAnswer((_) => Future.value(updatedFromDateOnlyTrip));
+
+          await providerContainer.read(tripsControllerProvider.future);
+          await expectLater(
+            providerContainer.read(tripsControllerProvider.notifier).updateTrip(
+                  tripId: validTripId,
+                  fromDate: updateFromDate,
+                ),
+            completes,
+          );
+          expect(
+            providerContainer.read(tripsControllerProvider).asData?.value,
+            [updatedFromDateOnlyTrip],
+          );
+          verify(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              validTitleValue,
+              updateFromDate,
+              validEndDate,
+            ),
+          ).called(1);
+          verifyNever(
+            mockExceptionHandler.handleException(
+              unexpectedException,
+            ),
+          );
+        },
+      );
+
+      test(
+        '正常系 帰着日だけを更新できる',
+        () async {
+          when(
+            mockTripInteractor.fetchTripsByUserId(validUserId),
+          ).thenAnswer(
+            (_) => Future.value([existingTrip]),
+          );
+          when(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              validTitleValue,
+              validFromDate,
+              updateEndDate,
+            ),
+          ).thenAnswer((_) => Future.value(updatedEndDateOnlyTrip));
+
+          await providerContainer.read(tripsControllerProvider.future);
+          await expectLater(
+            providerContainer.read(tripsControllerProvider.notifier).updateTrip(
+                  tripId: validTripId,
+                  endDate: updateEndDate,
+                ),
+            completes,
+          );
+          expect(
+            providerContainer.read(tripsControllerProvider).asData?.value,
+            [updatedEndDateOnlyTrip],
+          );
+          verify(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              validTitleValue,
+              validFromDate,
+              updateEndDate,
+            ),
+          ).called(1);
+          verifyNever(
+            mockExceptionHandler.handleException(
+              unexpectedException,
+            ),
+          );
+        },
+      );
+    },
+  );
+
   // TODO(seigi0714): generateAndCopyInviteLinkのテスト実装
 }

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -61,7 +61,7 @@ Future<void> main() async {
       ).thenReturn(null);
 
       await expectLater(
-        providerContainer.read(duplicatedTripControllerProvider).createTrip(
+        providerContainer.read(tripsControllerProvider.notifier).createTrip(
               title: validName,
               fromDate: validFromDate,
               endDate: validEndDate,
@@ -100,7 +100,7 @@ Future<void> main() async {
       ).thenThrow(unexpectedException);
 
       await expectLater(
-        providerContainer.read(duplicatedTripControllerProvider).createTrip(
+        providerContainer.read(tripsControllerProvider.notifier).createTrip(
               title: validName,
               fromDate: validFromDate,
               endDate: validEndDate,

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -128,59 +128,5 @@ Future<void> main() async {
     });
   });
 
-  group('fetchTripsByUserId', () {
-    test('正常系', () async {
-      when(
-        mockTripInteractor.fetchTripsByUserId(1),
-      ).thenAnswer((_) async => []);
-
-      await expectLater(
-        providerContainer
-            .read(duplicatedTripControllerProvider)
-            .fetchTripsByUserId(1),
-        completes,
-      );
-
-      verify(
-        mockTripInteractor.fetchTripsByUserId(1),
-      ).called(1);
-    });
-
-    test('準正常系 インタラクターがスローする例外のハンドリング', () async {
-      when(
-        mockExceptionHandler.handleException(
-          unexpectedException,
-        ),
-      ).thenReturn(null);
-
-      when(
-        mockTripInteractor.fetchTripsByUserId(1),
-      ).thenThrow(unexpectedException);
-
-      await expectLater(
-        () async {
-          await providerContainer
-              .read(duplicatedTripControllerProvider)
-              .fetchTripsByUserId(1);
-        },
-        throwsA(
-          isA<Exception>().having(
-            (e) => e.toString(),
-            'インタラクターが投げた例外をリスローしているか検証',
-            unexpectedException.toString(),
-          ),
-        ),
-      );
-
-      verify(
-        mockTripInteractor.fetchTripsByUserId(1),
-      ).called(1);
-
-      verify(
-        mockExceptionHandler.handleException(unexpectedException),
-      ).called(1);
-    });
-  });
-
   // TODO(seigi0714): generateAndCopyInviteLinkのテスト実装
 }

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -54,7 +54,6 @@ Future<void> main() async {
   );
   final mockFirebaseAuthUser =
       MockUser(email: validEmail, displayName: validName);
-  final mockAuth = await mockSignIn(mockFirebaseAuthUser);
   const validUserDataRes =
       GetUserResponse(id: validUserId, name: validName, email: validEmail);
   final validUserRes = <String, dynamic>{
@@ -76,6 +75,8 @@ Future<void> main() async {
         validUserRes,
       ),
     );
+
+    final mockAuth = await mockSignIn(mockFirebaseAuthUser);
 
     providerContainer = ProviderContainer(
       overrides: [
@@ -101,6 +102,7 @@ Future<void> main() async {
     reset(mockTripInteractor);
     reset(mockScaffoldMessengerHelper);
     reset(mockExceptionHandler);
+    reset(mockOnSuccess);
   });
 
   group('TripsController.build', () {
@@ -143,29 +145,29 @@ Future<void> main() async {
         mockTripInteractor.fetchTripsByUserId(validUserId),
       ).called(1);
     });
-  });
 
-  test('異常系 例外が生じた際は handleException が呼ばれる', () {
-    when(
-      mockTripInteractor.fetchTripsByUserId(validUserId),
-    ).thenThrow(unexpectedException);
+    test('異常系 例外が生じた際は handleException が呼ばれる', () {
+      when(
+        mockTripInteractor.fetchTripsByUserId(validUserId),
+      ).thenThrow(unexpectedException);
 
-    when(
-      mockExceptionHandler.handleException(
-        unexpectedException,
-      ),
-    ).thenReturn(null);
+      when(
+        mockExceptionHandler.handleException(
+          unexpectedException,
+        ),
+      ).thenReturn(null);
 
-    expect(
-      () => providerContainer.read(tripsControllerProvider.future),
-      throwsA(unexpectedException),
-    );
+      expect(
+        () => providerContainer.read(tripsControllerProvider.future),
+        throwsA(unexpectedException),
+      );
 
-    verify(
-      mockExceptionHandler.handleException(
-        unexpectedException,
-      ),
-    ).called(1);
+      verify(
+        mockExceptionHandler.handleException(
+          unexpectedException,
+        ),
+      ).called(1);
+    });
   });
 
   group('TripsController.createTrip', () {

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -103,17 +103,49 @@ Future<void> main() async {
     reset(mockExceptionHandler);
   });
 
-  group('createTrip', () {
-    final existingTrip = ExistingTrip(
-      id: validTripId,
-      title: TripTitle(value: validTitleValue),
-      period: TripPeriod(
-        fromDate: validFromDate,
-        endDate: validEndDate,
-      ),
-      members: [validMember],
-      belongings: [],
-    );
+  group('TripsController.build', () {
+    test('正常系', () async {
+      final testTrip = ExistingTrip(
+        id: validTripId,
+        title: TripTitle(value: validTitleValue),
+        period: TripPeriod(
+          fromDate: validFromDate,
+          endDate: validEndDate,
+        ),
+        members: [validMember],
+        belongings: [],
+      );
+
+      final expectedTripList = [
+        ExistingTrip(
+          id: validTripId,
+          title: TripTitle(value: validTitleValue),
+          period: TripPeriod(
+            fromDate: validFromDate,
+            endDate: validEndDate,
+          ),
+          members: [validMember],
+          belongings: [],
+        )
+      ];
+
+      when(
+        mockTripInteractor.fetchTripsByUserId(validUserId),
+      ).thenAnswer(
+        (_) => Future.value([testTrip]),
+      );
+
+      final result =
+          await providerContainer.read(tripsControllerProvider.future);
+
+      expect(result, expectedTripList);
+      verify(
+        mockTripInteractor.fetchTripsByUserId(validUserId),
+      ).called(1);
+    });
+  });
+
+  group('TripsController.createTrip', () {
     const newTripId = 2;
     final newTrip = ExistingTrip(
       id: newTripId,
@@ -130,7 +162,7 @@ Future<void> main() async {
     test('正常系', () async {
       when(
         mockTripInteractor.fetchTripsByUserId(validUserId),
-      ).thenAnswer((_) => Future.value([existingTrip]));
+      ).thenAnswer((_) async => <ExistingTrip>[]);
 
       when(
         mockTripInteractor.createTrip(
@@ -170,6 +202,7 @@ Future<void> main() async {
       ).called(1);
       verify(mockOnSuccess.showSnackBar('成功時コールバック')).called(1);
     });
+
     test('異常系 旅作成に失敗', () async {
       when(
         mockExceptionHandler.handleException(

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -1,12 +1,29 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:dio/dio.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:trip_app_nativeapp/core/exception/exception_handler.dart';
+import 'package:trip_app_nativeapp/core/http/api_client/api_destination.dart';
+import 'package:trip_app_nativeapp/core/http/api_client/dio/dio.dart';
+import 'package:trip_app_nativeapp/core/http/network_connectivity.dart';
+import 'package:trip_app_nativeapp/features/auth/data/repositories/firebase_auth_repository.dart';
 import 'package:trip_app_nativeapp/features/trips/controller/trip_controller.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_member.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_period.dart';
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_title.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/interactor/trip_interactor.dart';
+import 'package:trip_app_nativeapp/features/user/controller/app_user_controller.dart';
+import 'package:trip_app_nativeapp/features/user/data/models/get_user_response.dart';
+import 'package:trip_app_nativeapp/features/user/domain/entity/app_user.dart';
 import 'package:trip_app_nativeapp/view/widgets/helpers/scaffold_messenger.dart';
 
+import '../../../mock/async_value_listener.dart';
+import '../../../mock/mock_auth_helper.dart';
 import '../../../mock/mock_exception_handler.dart';
 import '../../../mock/mock_scaffold_messenger_helper.dart';
 import 'trip_controller_test.mocks.dart';
@@ -14,6 +31,7 @@ import 'trip_controller_test.mocks.dart';
 @GenerateMocks([TripInteractor])
 Future<void> main() async {
   late ProviderContainer providerContainer;
+  final dio = Dio(BaseOptions(validateStatus: (status) => true));
 
   final mockTripInteractor = MockTripInteractor();
   final mockScaffoldMessengerHelper = MockScaffoldMessengerHelper();
@@ -23,22 +41,62 @@ Future<void> main() async {
   // 実際にはScaffoldMessengerHelperのメソッドが呼ばれているわけでは無い
   final mockOnSuccess = MockScaffoldMessengerHelper();
 
-  const validName = 'test_user';
+  const validTripId = 1;
+  const validTitleValue = 'test_trip';
   final validFromDate = DateTime(2023);
   final validEndDate = DateTime(2023, 1, 2);
-
+  const validUserId = 1;
+  const validName = 'Bob';
+  const validEmail = 'bob@somedomain.com';
+  const validMember = TripMember.joined(
+    isHost: true,
+    user: AppUser(id: validUserId, name: validName, email: validEmail),
+  );
+  final mockFirebaseAuthUser =
+      MockUser(email: validEmail, displayName: validName);
+  final mockAuth = await mockSignIn(mockFirebaseAuthUser);
+  const validUserDataRes =
+      GetUserResponse(id: validUserId, name: validName, email: validEmail);
+  final validUserRes = <String, dynamic>{
+    'data': validUserDataRes.toJson(),
+  };
+  final mockConnectivity = Stream<ConnectivityResult>.fromIterable(
+    [ConnectivityResult.mobile],
+  );
+  final asyncValueListener =
+      AsyncValueListener<AsyncValue<List<ExistingTrip>>>();
   final unexpectedException = Exception('想定外のエラー');
 
-  setUp(() {
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    DioAdapter(dio: dio).onGet(
+      '/my/profile',
+      (server) => server.reply(
+        200,
+        validUserRes,
+      ),
+    );
+
     providerContainer = ProviderContainer(
       overrides: [
+        dioProvider(ApiDestination.privateTripAppV1).overrideWithValue(dio),
         tripInteractorProvider.overrideWith((_) => mockTripInteractor),
+        firebaseAuthProvider.overrideWithValue(mockAuth),
+        networkConnectivityProvider.overrideWith((ref) => mockConnectivity),
         scaffoldMessengerHelperProvider.overrideWith(
           (_) => mockScaffoldMessengerHelper,
         ),
         exceptionHandlerProvider.overrideWith((_) => mockExceptionHandler),
       ],
-    );
+    )..listen(
+        tripsControllerProvider,
+        asyncValueListener.call,
+        fireImmediately: true,
+      );
+
+    // TripsController.build() で appUserControllerProvider を watch しているので、
+    // appUserControllerProvider の初期化を完了させておく。
+    await providerContainer.read(appUserControllerProvider.future);
 
     reset(mockTripInteractor);
     reset(mockScaffoldMessengerHelper);
@@ -46,14 +104,42 @@ Future<void> main() async {
   });
 
   group('createTrip', () {
+    final existingTrip = ExistingTrip(
+      id: validTripId,
+      title: TripTitle(value: validTitleValue),
+      period: TripPeriod(
+        fromDate: validFromDate,
+        endDate: validEndDate,
+      ),
+      members: [validMember],
+      belongings: [],
+    );
+    const newTripId = 2;
+    final newTrip = ExistingTrip(
+      id: newTripId,
+      title: TripTitle(value: validTitleValue),
+      period: TripPeriod(
+        fromDate: validFromDate,
+        endDate: validEndDate,
+      ),
+      // TODO(shimizu-saffle): post のレスポンスにメンバー情報を含めるように改修次第テストデータを入れる
+      members: [],
+      belongings: [],
+    );
+
     test('正常系', () async {
       when(
+        mockTripInteractor.fetchTripsByUserId(validUserId),
+      ).thenAnswer((_) => Future.value([existingTrip]));
+
+      when(
         mockTripInteractor.createTrip(
-          validName,
+          validTitleValue,
           validFromDate,
           validEndDate,
         ),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) => Future.value(newTrip));
+
       when(
         mockScaffoldMessengerHelper.showSnackBar(
           createTripSuccessMessage,
@@ -62,7 +148,7 @@ Future<void> main() async {
 
       await expectLater(
         providerContainer.read(tripsControllerProvider.notifier).createTrip(
-              title: validName,
+              title: validTitleValue,
               fromDate: validFromDate,
               endDate: validEndDate,
               onSuccess: () => mockOnSuccess.showSnackBar('成功時コールバック'),
@@ -72,7 +158,7 @@ Future<void> main() async {
 
       verify(
         mockTripInteractor.createTrip(
-          validName,
+          validTitleValue,
           validFromDate,
           validEndDate,
         ),
@@ -93,7 +179,7 @@ Future<void> main() async {
 
       when(
         mockTripInteractor.createTrip(
-          validName,
+          validTitleValue,
           validFromDate,
           validEndDate,
         ),
@@ -101,7 +187,7 @@ Future<void> main() async {
 
       await expectLater(
         providerContainer.read(tripsControllerProvider.notifier).createTrip(
-              title: validName,
+              title: validTitleValue,
               fromDate: validFromDate,
               endDate: validEndDate,
               onSuccess: () => mockOnSuccess.showSnackBar('成功時コールバック'),
@@ -111,7 +197,7 @@ Future<void> main() async {
 
       verify(
         mockTripInteractor.createTrip(
-          validName,
+          validTitleValue,
           validFromDate,
           validEndDate,
         ),

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -509,21 +509,27 @@ Future<void> main() async {
         },
       );
 
-      test('異常系 引数の tripId に一致する ExistingTrip がない場合は AppException を投げる', () {
+      test('異常系 引数の tripId に一致する ExistingTrip がない場合は AppException を投げる',
+          () async {
         when(
           mockTripInteractor.fetchTripsByUserId(validUserId),
         ).thenAnswer(
           (_) => Future.value(<ExistingTrip>[]),
         );
-        expect(
+        await expectLater(
           providerContainer.read(tripsControllerProvider.notifier).updateTrip(
                 tripId: 999,
                 title: updateTripTitleValue,
                 fromDate: updateFromDate,
                 endDate: updateEndDate,
               ),
-          throwsA(isA<AppException>()),
+          completes,
         );
+        verify(
+          mockExceptionHandler.handleException(
+            const AppException(message: '更新しようとしている旅が存在していません🤔'),
+          ),
+        ).called(1);
       });
 
       test(
@@ -551,10 +557,17 @@ Future<void> main() async {
                   fromDate: updateFromDate,
                   endDate: updateEndDate,
                 ),
-            throwsA(
-              isA<Exception>(),
-            ),
+            completes,
           );
+
+          verify(
+            mockTripInteractor.updateTrip(
+              validTripId,
+              updateTripTitleValue,
+              updateFromDate,
+              updateEndDate,
+            ),
+          ).called(1);
           verify(
             mockExceptionHandler.handleException(
               unexpectedException,

--- a/test/feature/trips/controller/trip_controller_test.dart
+++ b/test/feature/trips/controller/trip_controller_test.dart
@@ -61,7 +61,7 @@ Future<void> main() async {
       ).thenReturn(null);
 
       await expectLater(
-        providerContainer.read(tripControllerProvider).createTrip(
+        providerContainer.read(duplicatedTripControllerProvider).createTrip(
               title: validName,
               fromDate: validFromDate,
               endDate: validEndDate,
@@ -100,7 +100,7 @@ Future<void> main() async {
       ).thenThrow(unexpectedException);
 
       await expectLater(
-        providerContainer.read(tripControllerProvider).createTrip(
+        providerContainer.read(duplicatedTripControllerProvider).createTrip(
               title: validName,
               fromDate: validFromDate,
               endDate: validEndDate,
@@ -135,7 +135,9 @@ Future<void> main() async {
       ).thenAnswer((_) async => []);
 
       await expectLater(
-        providerContainer.read(tripControllerProvider).fetchTripsByUserId(1),
+        providerContainer
+            .read(duplicatedTripControllerProvider)
+            .fetchTripsByUserId(1),
         completes,
       );
 
@@ -158,7 +160,7 @@ Future<void> main() async {
       await expectLater(
         () async {
           await providerContainer
-              .read(tripControllerProvider)
+              .read(duplicatedTripControllerProvider)
               .fetchTripsByUserId(1);
         },
         throwsA(

--- a/test/feature/trips/controller/trip_controller_test.mocks.dart
+++ b/test/feature/trips/controller/trip_controller_test.mocks.dart
@@ -3,17 +3,17 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i6;
+import 'dart:async' as _i7;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip.dart'
-    as _i7;
-import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_belonging.dart'
-    as _i4;
-import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_invitation.dart'
     as _i3;
-import 'package:trip_app_nativeapp/features/trips/domain/interactor/trip_interactor.dart'
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_belonging.dart'
     as _i5;
+import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/trip_invitation.dart'
+    as _i4;
+import 'package:trip_app_nativeapp/features/trips/domain/interactor/trip_interactor.dart'
+    as _i6;
 import 'package:trip_app_nativeapp/features/trips/domain/repositories/trip_repository_interface.dart'
     as _i2;
 
@@ -39,9 +39,8 @@ class _FakeTripRepositoryInterface_0 extends _i1.SmartFake
         );
 }
 
-class _FakeGeneratedTripInvitation_1 extends _i1.SmartFake
-    implements _i3.GeneratedTripInvitation {
-  _FakeGeneratedTripInvitation_1(
+class _FakeExistingTrip_1 extends _i1.SmartFake implements _i3.ExistingTrip {
+  _FakeExistingTrip_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -50,9 +49,20 @@ class _FakeGeneratedTripInvitation_1 extends _i1.SmartFake
         );
 }
 
-class _FakeAddedTripBelonging_2 extends _i1.SmartFake
-    implements _i4.AddedTripBelonging {
-  _FakeAddedTripBelonging_2(
+class _FakeGeneratedTripInvitation_2 extends _i1.SmartFake
+    implements _i4.GeneratedTripInvitation {
+  _FakeGeneratedTripInvitation_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAddedTripBelonging_3 extends _i1.SmartFake
+    implements _i5.AddedTripBelonging {
+  _FakeAddedTripBelonging_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -64,7 +74,7 @@ class _FakeAddedTripBelonging_2 extends _i1.SmartFake
 /// A class which mocks [TripInteractor].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
+class MockTripInteractor extends _i1.Mock implements _i6.TripInteractor {
   MockTripInteractor() {
     _i1.throwOnMissingStub(this);
   }
@@ -78,7 +88,7 @@ class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
         ),
       ) as _i2.TripRepositoryInterface);
   @override
-  _i6.Future<void> createTrip(
+  _i7.Future<void> createTrip(
     String? title,
     DateTime? fromDate,
     DateTime? endDate,
@@ -92,11 +102,41 @@ class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
             endDate,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
   @override
-  _i6.Future<_i3.GeneratedTripInvitation> invite({
+  _i7.Future<_i3.ExistingTrip> updateTrip(
+    int? id,
+    String? title,
+    DateTime? fromDate,
+    DateTime? endDate,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateTrip,
+          [
+            id,
+            title,
+            fromDate,
+            endDate,
+          ],
+        ),
+        returnValue: _i7.Future<_i3.ExistingTrip>.value(_FakeExistingTrip_1(
+          this,
+          Invocation.method(
+            #updateTrip,
+            [
+              id,
+              title,
+              fromDate,
+              endDate,
+            ],
+          ),
+        )),
+      ) as _i7.Future<_i3.ExistingTrip>);
+  @override
+  _i7.Future<_i4.GeneratedTripInvitation> invite({
     required int? tripId,
     required int? invitationNum,
   }) =>
@@ -109,8 +149,8 @@ class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
             #invitationNum: invitationNum,
           },
         ),
-        returnValue: _i6.Future<_i3.GeneratedTripInvitation>.value(
-            _FakeGeneratedTripInvitation_1(
+        returnValue: _i7.Future<_i4.GeneratedTripInvitation>.value(
+            _FakeGeneratedTripInvitation_2(
           this,
           Invocation.method(
             #invite,
@@ -121,19 +161,19 @@ class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
             },
           ),
         )),
-      ) as _i6.Future<_i3.GeneratedTripInvitation>);
+      ) as _i7.Future<_i4.GeneratedTripInvitation>);
   @override
-  _i6.Future<List<_i7.ExistingTrip>> fetchTripsByUserId(int? userId) =>
+  _i7.Future<List<_i3.ExistingTrip>> fetchTripsByUserId(int? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchTripsByUserId,
           [userId],
         ),
         returnValue:
-            _i6.Future<List<_i7.ExistingTrip>>.value(<_i7.ExistingTrip>[]),
-      ) as _i6.Future<List<_i7.ExistingTrip>>);
+            _i7.Future<List<_i3.ExistingTrip>>.value(<_i3.ExistingTrip>[]),
+      ) as _i7.Future<List<_i3.ExistingTrip>>);
   @override
-  _i6.Future<_i4.AddedTripBelonging> addTripBelonging({
+  _i7.Future<_i5.AddedTripBelonging> addTripBelonging({
     required int? tripId,
     required String? name,
     required int? numOf,
@@ -151,7 +191,7 @@ class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
           },
         ),
         returnValue:
-            _i6.Future<_i4.AddedTripBelonging>.value(_FakeAddedTripBelonging_2(
+            _i7.Future<_i5.AddedTripBelonging>.value(_FakeAddedTripBelonging_3(
           this,
           Invocation.method(
             #addTripBelonging,
@@ -164,20 +204,20 @@ class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
             },
           ),
         )),
-      ) as _i6.Future<_i4.AddedTripBelonging>);
+      ) as _i7.Future<_i5.AddedTripBelonging>);
   @override
-  _i6.Future<List<_i4.AddedTripBelonging>> fetchTripBelongings(int? tripId) =>
+  _i7.Future<List<_i5.AddedTripBelonging>> fetchTripBelongings(int? tripId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchTripBelongings,
           [tripId],
         ),
-        returnValue: _i6.Future<List<_i4.AddedTripBelonging>>.value(
-            <_i4.AddedTripBelonging>[]),
-      ) as _i6.Future<List<_i4.AddedTripBelonging>>);
+        returnValue: _i7.Future<List<_i5.AddedTripBelonging>>.value(
+            <_i5.AddedTripBelonging>[]),
+      ) as _i7.Future<List<_i5.AddedTripBelonging>>);
   @override
-  _i6.Future<_i4.AddedTripBelonging> changeBelongingCheckStatus(
-          {required _i4.AddedTripBelonging? belonging}) =>
+  _i7.Future<_i5.AddedTripBelonging> changeBelongingCheckStatus(
+          {required _i5.AddedTripBelonging? belonging}) =>
       (super.noSuchMethod(
         Invocation.method(
           #changeBelongingCheckStatus,
@@ -185,7 +225,7 @@ class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
           {#belonging: belonging},
         ),
         returnValue:
-            _i6.Future<_i4.AddedTripBelonging>.value(_FakeAddedTripBelonging_2(
+            _i7.Future<_i5.AddedTripBelonging>.value(_FakeAddedTripBelonging_3(
           this,
           Invocation.method(
             #changeBelongingCheckStatus,
@@ -193,5 +233,5 @@ class MockTripInteractor extends _i1.Mock implements _i5.TripInteractor {
             {#belonging: belonging},
           ),
         )),
-      ) as _i6.Future<_i4.AddedTripBelonging>);
+      ) as _i7.Future<_i5.AddedTripBelonging>);
 }

--- a/test/feature/trips/controller/trip_controller_test.mocks.dart
+++ b/test/feature/trips/controller/trip_controller_test.mocks.dart
@@ -88,7 +88,7 @@ class MockTripInteractor extends _i1.Mock implements _i6.TripInteractor {
         ),
       ) as _i2.TripRepositoryInterface);
   @override
-  _i7.Future<void> createTrip(
+  _i7.Future<_i3.ExistingTrip> createTrip(
     String? title,
     DateTime? fromDate,
     DateTime? endDate,
@@ -102,9 +102,18 @@ class MockTripInteractor extends _i1.Mock implements _i6.TripInteractor {
             endDate,
           ],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i7.Future<_i3.ExistingTrip>.value(_FakeExistingTrip_1(
+          this,
+          Invocation.method(
+            #createTrip,
+            [
+              title,
+              fromDate,
+              endDate,
+            ],
+          ),
+        )),
+      ) as _i7.Future<_i3.ExistingTrip>);
   @override
   _i7.Future<_i3.ExistingTrip> updateTrip(
     int? id,

--- a/test/feature/trips/domain/entity/value/trip_title_test.dart
+++ b/test/feature/trips/domain/entity/value/trip_title_test.dart
@@ -1,33 +1,43 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:trip_app_nativeapp/core/exception/app_exception.dart';
-import 'package:trip_app_nativeapp/core/exception/exception_code.dart';
 import 'package:trip_app_nativeapp/features/trips/domain/entity/trip/value/trip_title.dart';
 
-Future<void> main() async {
+void main() {
   const validTitle = 'test_user';
   const emptyTitle = '';
+  const longTitle = 'test_title_test_title_test_title_test_title_test_title';
 
   group('TripTitle コンストラクタ', () {
-    test('正常系', () async {
+    test('正常系', () {
       expect(() => TripTitle(value: validTitle), returnsNormally);
     });
-    test('純正常系 タイトルは空文字は受け付けない', () async {
+    test('異常系 タイトルは空文字は受け付けない', () {
       expect(
         () => TripTitle(value: emptyTitle),
         throwsA(
-          isA<AppException>()
-              .having(
-                (e) => e.code,
-                'errorCode',
-                ExceptionCode.invalidTripTitle,
-              )
-              .having(
-                (e) => e.message,
-                'errorMessage',
-                '旅のタイトルが空文字です。',
-              ),
+          isA<AssertionError>().having(
+            (e) => e.message,
+            'message',
+            'UI のコードによって、空文字が入力されないように制御してください',
+          ),
         ),
       );
     });
+
+    test(
+      '異常系 26文字以上のタイトルは受け付けない',
+      () {
+        expect(
+          () => TripTitle(value: longTitle),
+          throwsA(
+            isA<AssertionError>().having(
+              (e) => e.message,
+              'message',
+              'UI のコードによって、26文字以上の文字列が入力されないように制御してください',
+            ),
+          ),
+          reason: '26文字以上の場合 trip-app-backend がエラーを返すため',
+        );
+      },
+    );
   });
 }

--- a/test/feature/trips/domain/trip_interactor_test.dart
+++ b/test/feature/trips/domain/trip_interactor_test.dart
@@ -25,6 +25,10 @@ void main() {
   const validUserId = 1;
   const validName = 'Bob';
   const validEmail = 'bob@somedomain.com';
+  const validMember = TripMember.joined(
+    isHost: true,
+    user: AppUser(id: validUserId, name: validName, email: validEmail),
+  );
 
   setUp(() {
     providerContainer = ProviderContainer(
@@ -44,16 +48,7 @@ void main() {
               fromDate: validFromDate,
               endDate: validEndDate,
             ),
-            members: [
-              const TripMember.joined(
-                isHost: true,
-                user: AppUser(
-                  id: validUserId,
-                  name: validName,
-                  email: validEmail,
-                ),
-              ),
-            ],
+            members: [validMember],
             belongings: [],
           ) as ExistingTrip
         ]),
@@ -94,11 +89,6 @@ void main() {
         members: [],
         belongings: [],
       ) as ExistingTrip;
-
-      const validMember = TripMember.joined(
-        isHost: true,
-        user: AppUser(id: validUserId, name: validName, email: validEmail),
-      );
 
       final expectedTrip = Trip.createExistingTrip(
         id: validTripId,

--- a/test/feature/user/controller/app_user_controller_test.dart
+++ b/test/feature/user/controller/app_user_controller_test.dart
@@ -1,9 +1,7 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_sign_in_mocks/google_sign_in_mocks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,6 +14,7 @@ import 'package:trip_app_nativeapp/features/user/data/models/get_user_response.d
 import 'package:trip_app_nativeapp/features/user/domain/entity/app_user.dart';
 
 import '../../../mock/async_value_listener.dart';
+import '../../../mock/mock_auth_helper.dart';
 
 Future<void> main() async {
   group(
@@ -49,7 +48,7 @@ Future<void> main() async {
       test(
         '正常系 Firebase Auth がログイン状態の場合は AppUser が取得できている',
         () async {
-          final mockAuth = await _mockSignIn(firebaseAuthUser);
+          final mockAuth = await mockSignIn(firebaseAuthUser);
 
           container = ProviderContainer(
             overrides: [
@@ -139,16 +138,4 @@ Future<void> main() async {
       );
     },
   );
-}
-
-Future<MockFirebaseAuth> _mockSignIn(MockUser firebaseAuthUser) async {
-  final googleUser = await MockGoogleSignIn().signIn();
-  final signInAccount = await googleUser?.authentication;
-  final credential = GoogleAuthProvider.credential(
-    accessToken: signInAccount?.accessToken,
-    idToken: signInAccount?.idToken,
-  );
-  final mockAuth = MockFirebaseAuth(mockUser: firebaseAuthUser);
-  await mockAuth.signInWithCredential(credential);
-  return mockAuth;
 }

--- a/test/feature/user/controller/app_user_controller_test.dart
+++ b/test/feature/user/controller/app_user_controller_test.dart
@@ -58,13 +58,13 @@ Future<void> main() async {
               networkConnectivityProvider
                   .overrideWith((ref) => mockConnectivity),
             ],
-          )
-            ..listen(
+          )..listen(
               appUserControllerProvider,
               asyncValueListener.call,
               fireImmediately: true,
-            )
-            ..read(appUserControllerProvider);
+            );
+
+          await container.read(appUserControllerProvider.future);
 
           verify(
             () => asyncValueListener(
@@ -72,9 +72,6 @@ Future<void> main() async {
               const AsyncLoading<AppUser?>(),
             ),
           );
-
-          // /my/profile [get] からの response が返ってくるまで待つ
-          await Future<void>.delayed(const Duration(seconds: 1));
 
           verify(
             () => asyncValueListener(

--- a/test/mock/mock_auth_helper.dart
+++ b/test/mock/mock_auth_helper.dart
@@ -1,8 +1,43 @@
+import 'package:dio/dio.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:google_sign_in_mocks/google_sign_in_mocks.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
 
-Future<MockFirebaseAuth> mockSignIn(MockUser firebaseAuthUser) async {
+/// Firebase Auth のサインインをシミュレートし、 Dio のモックレスポンスを設定することで、
+/// ユーザーログインプロセスをモックする。
+///
+/// * [dio] モックレスポンスが付与される [Dio] のインスタンス。
+/// * [mockUserRes] Dio インスタンスによって返されるモックユーザーレスポンスデータ。
+/// * [mockFirebaseUser] サインインシミュレーションに使用されるモック Firebase Auth ユーザー。
+///
+/// サインインシミュレーション済みの MockFirebaseAuth インスタンスと、
+/// モックレスポンスが付与された Dio インスタンスを返す。
+Future<(MockFirebaseAuth, Dio)> mockLogin({
+  required Dio dio,
+  required Map<String, dynamic> mockUserRes,
+  required MockUser mockFirebaseUser,
+}) async {
+  return (
+    await _mockFirebaseAuthSignIn(mockFirebaseUser),
+    _setDioMockResponse(dio, mockUserRes)
+  );
+}
+
+Dio _setDioMockResponse(Dio dio, Map<String, dynamic> mockUserRes) {
+  DioAdapter(dio: dio).onGet(
+    '/my/profile',
+    (server) => server.reply(
+      200,
+      mockUserRes,
+    ),
+  );
+  return dio;
+}
+
+Future<MockFirebaseAuth> _mockFirebaseAuthSignIn(
+  MockUser firebaseAuthUser,
+) async {
   final googleUser = await MockGoogleSignIn().signIn();
   final signInAccount = await googleUser?.authentication;
   final credential = GoogleAuthProvider.credential(

--- a/test/mock/mock_auth_helper.dart
+++ b/test/mock/mock_auth_helper.dart
@@ -1,0 +1,15 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:google_sign_in_mocks/google_sign_in_mocks.dart';
+
+Future<MockFirebaseAuth> mockSignIn(MockUser firebaseAuthUser) async {
+  final googleUser = await MockGoogleSignIn().signIn();
+  final signInAccount = await googleUser?.authentication;
+  final credential = GoogleAuthProvider.credential(
+    accessToken: signInAccount?.accessToken,
+    idToken: signInAccount?.idToken,
+  );
+  final mockAuth = MockFirebaseAuth(mockUser: firebaseAuthUser);
+  await mockAuth.signInWithCredential(credential);
+  return mockAuth;
+}


### PR DESCRIPTION
## 概要

旅情報更新機能の view, controller を実装して、ユーザーが旅情報を更新できるようにしました！

### 変更点

- 既存の TripController, tripsProvider を TripsController（AsyncNotifier のサブクラス） に置き換え
  - 理由：一つの旅を更新した時に、バックエンドから一覧取得してリビルドするのを避けるため
- 上記に伴って、既存のテストコードを書き換えて、`TripsController.updateTrip` のテストを追加
- Flutter 3.10.6 に上げた
- riverpod_generator で生成される provider が提供する値を freezed で生成したクラスに指定すると、型が dynamic になる問題を修正

その他、変更点の説明は diff にコメントしています！

### キャプチャ
<img src="https://github.com/seigi0714/trip-app-nativeapp/assets/85660846/943188ec-61d5-41df-9f37-59a8b957810b" width="450px"/>

#### 備考
diff おっきくてごめん🙏